### PR TITLE
Update to Tklayout v3.03

### DIFF
--- a/FCChh/compact/FCChh_Option3_v03/FCChh_Option3_v03.xml
+++ b/FCChh/compact/FCChh_Option3_v03/FCChh_Option3_v03.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0" xmlns:xs="http://www.w3.org/2001/XMLSchema" xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+    <info name="TkLayoutTracker" title="TkLayoutTracker" author="Z.Drasal" url="http://fcc-tklayout.web.cern.ch/fcc-tklayout" status="optimization" version="FCChh_Option3">
+        <comment>The tracker geometry as designed and optimized by tkLayout software - design version: FCChh_Option3</comment>
+    </info>
+  <includes>
+    <gdmlFile  ref="elements.xml"/>
+    <gdmlFile  ref="materials.xml"/>
+  </includes>
+
+    <define>
+      <constant name="world_side"             value="30000*mm"/>
+      <constant name="world_x"                value="world_side"/>
+      <constant name="world_y"                value="world_side"/>
+      <constant name="world_z"                value="world_side"/>
+    </define>
+
+    <readouts>
+        <readout name="TrackerBarrelReadout1">
+            <segmentation type="CartesianGridXZ" grid_size_x="0.005*mm" grid_size_z="0.010*mm"/>
+            <id>system:5,side:-2,layer:5,module:16,x:-15,z:-15</id>
+        </readout>
+        <readout name="TrackerBarrelReadout2">
+            <segmentation type="CartesianGridXZ" grid_size_x="0.005*mm" grid_size_z="0.010*mm"/>
+            <id>system:5,side:-2,layer:5,module:16,x:-15,z:-15</id>
+        </readout>
+        <readout name="TrackerBarrelReadout3">
+            <segmentation type="CartesianGridXZ" grid_size_x="0.005*mm" grid_size_z="0.010*mm"/>
+            <id>system:5,side:-2,layer:5,module:16,x:-15,z:-15</id>
+        </readout>
+        <readout name="TrackerEndcapReadout1">
+            <segmentation type="CartesianGridXZ" grid_size_x="0.005*mm" grid_size_z="0.010*mm"/>
+            <id>system:5,side:-2,layer:5,module:16,x:-15,z:-15</id>
+        </readout>
+        <readout name="TrackerEndcapReadout2">
+            <segmentation type="CartesianGridXZ" grid_size_x="0.005*mm" grid_size_z="0.010*mm"/>
+            <id>system:5,side:-2,layer:5,module:16,x:-15,z:-15</id>
+        </readout>
+        <readout name="TrackerEndcapReadout3">
+            <segmentation type="CartesianGridXZ" grid_size_x="0.005*mm" grid_size_z="0.010*mm"/>
+            <id>system:5,side:-2,layer:5,module:16,x:-15,z:-15</id>
+        </readout>
+        <readout name="TrackerEndcapReadout4">
+            <segmentation type="CartesianGridXZ" grid_size_x="0.005*mm" grid_size_z="0.010*mm"/>
+            <id>system:5,side:-2,layer:5,module:16,x:-15,z:-15</id>
+        </readout>
+        <readout name="TrackerEndcapReadout5">
+            <segmentation type="CartesianGridXZ" grid_size_x="0.005*mm" grid_size_z="0.010*mm"/>
+            <id>system:5,side:-2,layer:5,module:16,x:-15,z:-15</id>
+        </readout>
+        <readout name="TrackerEndcapReadout6">
+            <segmentation type="CartesianGridXZ" grid_size_x="0.005*mm" grid_size_z="0.010*mm"/>
+            <id>system:5,side:-2,layer:5,module:16,x:-15,z:-15</id>
+        </readout>
+    </readouts>
+
+<include ref="FCChh_v3.03_Definitions.xml"/>
+
+
+    <plugins>
+      <plugin name="DD4hep_GenericSurfaceInstallerPlugin">
+        <argument value="InnerBRL_Inner0"/>
+        <argument value="dimension=2"/>
+        <argument value="u_x=-1."/>
+        <argument value="v_y=-1."/>
+        <argument value="n_z=1."/>
+      </plugin>	
+      <plugin name="DD4hep_GenericSurfaceInstallerPlugin">
+        <argument value="InnerBRL_Inner1"/>
+        <argument value="dimension=2"/>
+        <argument value="u_x=-1."/>
+        <argument value="v_y=1."/>
+        <argument value="n_z=1."/>
+      </plugin>
+      <plugin name="DD4hep_GenericSurfaceInstallerPlugin">
+        <argument value="InnerECAPpos"/>
+        <argument value="dimension=2"/>
+        <argument value="u_x=-1."/>
+        <argument value="v_y=1."/>
+        <argument value="n_z=1."/>
+      </plugin>
+      <plugin name="DD4hep_GenericSurfaceInstallerPlugin">
+        <argument value="InnerECAPneg"/>
+        <argument value="dimension=2"/>
+        <argument value="u_x=-1."/>
+        <argument value="v_y=1."/>
+        <argument value="n_z=1."/>
+      </plugin>
+      <plugin name="DD4hep_GenericSurfaceInstallerPlugin">
+        <argument value="OuterBRL"/>
+        <argument value="dimension=2"/>
+        <argument value="u_x=-1."/>
+        <argument value="v_y=1."/>
+        <argument value="n_z=1."/>
+      </plugin>
+      <plugin name="DD4hep_GenericSurfaceInstallerPlugin">
+        <argument value="OuterECAP"/>
+        <argument value="dimension=2"/>
+        <argument value="u_x=-1."/>
+        <argument value="v_y=1."/>
+        <argument value="n_z=1."/>
+      </plugin>
+      <plugin name="DD4hep_GenericSurfaceInstallerPlugin">
+        <argument value="OuterECAPneg"/>
+        <argument value="dimension=2"/>
+        <argument value="u_x=-1."/>
+        <argument value="v_y=1."/>
+        <argument value="n_z=1."/>
+      </plugin>
+      <!-- <plugin name="DD4hep_GenericSurfaceInstallerPlugin"> -->
+      <!--   <argument value="FwdECAPpos"/> -->
+      <!--   <argument value="dimension=2"/> -->
+      <!--   <argument value="u_x=-1."/> -->
+      <!--   <argument value="v_y=1."/> -->
+      <!--   <argument value="n_z=1."/> -->
+      <!-- </plugin> -->
+      <!-- <plugin name="DD4hep_GenericSurfaceInstallerPlugin"> -->
+      <!--   <argument value="FwdECAPneg"/> -->
+      <!--   <argument value="dimension=2"/> -->
+      <!--   <argument value="u_x=-1."/> -->
+      <!--   <argument value="v_y=1."/> -->
+      <!--   <argument value="n_z=1."/> -->
+      <!-- </plugin> -->
+    </plugins>
+    <plugins>
+      <plugin name="InstallSurfaceManager"/>
+    </plugins>
+    
+    
+</lccdd>

--- a/FCChh/compact/FCChh_Option3_v03/FCChh_Option3_v03.xml
+++ b/FCChh/compact/FCChh_Option3_v03/FCChh_Option3_v03.xml
@@ -59,14 +59,14 @@
 
     <plugins>
       <plugin name="DD4hep_GenericSurfaceInstallerPlugin">
-        <argument value="InnerBRL_Inner0"/>
+        <argument value="InnerBRL_0"/>
         <argument value="dimension=2"/>
         <argument value="u_x=-1."/>
         <argument value="v_y=-1."/>
         <argument value="n_z=1."/>
       </plugin>	
       <plugin name="DD4hep_GenericSurfaceInstallerPlugin">
-        <argument value="InnerBRL_Inner1"/>
+        <argument value="InnerBRL_1"/>
         <argument value="dimension=2"/>
         <argument value="u_x=-1."/>
         <argument value="v_y=1."/>
@@ -94,7 +94,7 @@
         <argument value="n_z=1."/>
       </plugin>
       <plugin name="DD4hep_GenericSurfaceInstallerPlugin">
-        <argument value="OuterECAP"/>
+        <argument value="OuterECAPpos"/>
         <argument value="dimension=2"/>
         <argument value="u_x=-1."/>
         <argument value="v_y=1."/>

--- a/FCChh/compact/FCChh_Option3_v03/FCChh_v3.03_Definitions.xml
+++ b/FCChh/compact/FCChh_Option3_v03/FCChh_v3.03_Definitions.xml
@@ -1,0 +1,3832 @@
+<detectors>
+    <detector name="InnerBRL_0" id="BarTrackerInner_id" type="TkLayoutBrlTracker" readout="TrackerBarrelReadout">
+        <dimensions rmin="23.283*mm" rmax="152.256*mm" zmin="-820.000*mm" zmax="820.000*mm"/>
+        <sensitive type="SimpleTrackerSD"/>
+        <layers repeat="4">
+            <layer id="1" radius="25.000*mm" rmin="23.283*mm" rmax="27.473*mm" bigDelta="1.000*mm" phi0="1.570796*rad">
+                <rods repeat="14" smallDelta="0.000*mm" rPhiOverlap="0.000*mm" nRPhiSegments="2" zOverlap="0.000*mm" nModules="20">
+                    <rodOdd id="1">
+                        <modules>
+                            <module id="1" X="0.000*mm" Y="26.000*mm" Z="-650.750*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="2" X="0.000*mm" Y="26.000*mm" Z="-582.250*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="3" X="0.000*mm" Y="26.000*mm" Z="-513.750*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="4" X="0.000*mm" Y="26.000*mm" Z="-445.250*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="5" X="0.000*mm" Y="26.000*mm" Z="-376.750*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="6" X="0.000*mm" Y="26.000*mm" Z="-308.250*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="7" X="0.000*mm" Y="26.000*mm" Z="-239.750*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="8" X="0.000*mm" Y="26.000*mm" Z="-171.250*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="9" X="0.000*mm" Y="26.000*mm" Z="-102.750*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="10" X="0.000*mm" Y="26.000*mm" Z="-34.250*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="11" X="0.000*mm" Y="26.000*mm" Z="34.250*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="12" X="0.000*mm" Y="26.000*mm" Z="102.750*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="13" X="0.000*mm" Y="26.000*mm" Z="171.250*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="14" X="0.000*mm" Y="26.000*mm" Z="239.750*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="15" X="0.000*mm" Y="26.000*mm" Z="308.250*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="16" X="0.000*mm" Y="26.000*mm" Z="376.750*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="17" X="0.000*mm" Y="26.000*mm" Z="445.250*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="18" X="0.000*mm" Y="26.000*mm" Z="513.750*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="19" X="0.000*mm" Y="26.000*mm" Z="582.250*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="20" X="0.000*mm" Y="26.000*mm" Z="650.750*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                        </modules>
+                        <moduleProperties modLength="68.500*mm" modWidth="12.800*mm" modThickness="1.434*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.187*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.029*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.086*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="0.602*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.430*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="68.500*mm" sensorWidth="12.800*mm" sensorThickness="0.100*mm" resRPhi="7.5*um" resZ="15.0*um"/>
+                    </rodOdd>
+                    <rodEven id="2">
+                        <modules>
+                            <module id="1" X="-10.413*mm" Y="21.623*mm" Z="-650.750*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="2" X="-10.413*mm" Y="21.623*mm" Z="-582.250*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="3" X="-10.413*mm" Y="21.623*mm" Z="-513.750*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="4" X="-10.413*mm" Y="21.623*mm" Z="-445.250*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="5" X="-10.413*mm" Y="21.623*mm" Z="-376.750*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="6" X="-10.413*mm" Y="21.623*mm" Z="-308.250*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="7" X="-10.413*mm" Y="21.623*mm" Z="-239.750*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="8" X="-10.413*mm" Y="21.623*mm" Z="-171.250*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="9" X="-10.413*mm" Y="21.623*mm" Z="-102.750*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="10" X="-10.413*mm" Y="21.623*mm" Z="-34.250*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="11" X="-10.413*mm" Y="21.623*mm" Z="34.250*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="12" X="-10.413*mm" Y="21.623*mm" Z="102.750*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="13" X="-10.413*mm" Y="21.623*mm" Z="171.250*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="14" X="-10.413*mm" Y="21.623*mm" Z="239.750*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="15" X="-10.413*mm" Y="21.623*mm" Z="308.250*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="16" X="-10.413*mm" Y="21.623*mm" Z="376.750*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="17" X="-10.413*mm" Y="21.623*mm" Z="445.250*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="18" X="-10.413*mm" Y="21.623*mm" Z="513.750*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="19" X="-10.413*mm" Y="21.623*mm" Z="582.250*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="20" X="-10.413*mm" Y="21.623*mm" Z="650.750*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                        </modules>
+                        <moduleProperties modLength="68.500*mm" modWidth="12.800*mm" modThickness="1.434*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.187*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.029*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.086*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="0.602*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.430*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="68.500*mm" sensorWidth="12.800*mm" sensorThickness="0.100*mm" resRPhi="7.5*um" resZ="15.0*um"/>
+                    </rodEven>
+                </rods>
+            </layer>
+            <layer id="2" radius="60.000*mm" rmin="58.283*mm" rmax="63.030*mm" bigDelta="1.000*mm" phi0="1.570796*rad">
+                <rods repeat="16" smallDelta="0.000*mm" rPhiOverlap="0.000*mm" nRPhiSegments="2" zOverlap="0.000*mm" nModules="40">
+                    <rodOdd id="1">
+                        <modules>
+                            <module id="1" X="0.000*mm" Y="61.000*mm" Z="-799.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="2" X="0.000*mm" Y="61.000*mm" Z="-758.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="3" X="0.000*mm" Y="61.000*mm" Z="-717.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="4" X="0.000*mm" Y="61.000*mm" Z="-676.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="5" X="0.000*mm" Y="61.000*mm" Z="-635.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="6" X="0.000*mm" Y="61.000*mm" Z="-594.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="7" X="0.000*mm" Y="61.000*mm" Z="-553.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="8" X="0.000*mm" Y="61.000*mm" Z="-512.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="9" X="0.000*mm" Y="61.000*mm" Z="-471.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="10" X="0.000*mm" Y="61.000*mm" Z="-430.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="11" X="0.000*mm" Y="61.000*mm" Z="-389.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="12" X="0.000*mm" Y="61.000*mm" Z="-348.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="13" X="0.000*mm" Y="61.000*mm" Z="-307.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="14" X="0.000*mm" Y="61.000*mm" Z="-266.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="15" X="0.000*mm" Y="61.000*mm" Z="-225.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="16" X="0.000*mm" Y="61.000*mm" Z="-184.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="17" X="0.000*mm" Y="61.000*mm" Z="-143.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="18" X="0.000*mm" Y="61.000*mm" Z="-102.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="19" X="0.000*mm" Y="61.000*mm" Z="-61.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="20" X="0.000*mm" Y="61.000*mm" Z="-20.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="21" X="0.000*mm" Y="61.000*mm" Z="20.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="22" X="0.000*mm" Y="61.000*mm" Z="61.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="23" X="0.000*mm" Y="61.000*mm" Z="102.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="24" X="0.000*mm" Y="61.000*mm" Z="143.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="25" X="0.000*mm" Y="61.000*mm" Z="184.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="26" X="0.000*mm" Y="61.000*mm" Z="225.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="27" X="0.000*mm" Y="61.000*mm" Z="266.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="28" X="0.000*mm" Y="61.000*mm" Z="307.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="29" X="0.000*mm" Y="61.000*mm" Z="348.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="30" X="0.000*mm" Y="61.000*mm" Z="389.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="31" X="0.000*mm" Y="61.000*mm" Z="430.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="32" X="0.000*mm" Y="61.000*mm" Z="471.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="33" X="0.000*mm" Y="61.000*mm" Z="512.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="34" X="0.000*mm" Y="61.000*mm" Z="553.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="35" X="0.000*mm" Y="61.000*mm" Z="594.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="36" X="0.000*mm" Y="61.000*mm" Z="635.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="37" X="0.000*mm" Y="61.000*mm" Z="676.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="38" X="0.000*mm" Y="61.000*mm" Z="717.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="39" X="0.000*mm" Y="61.000*mm" Z="758.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="40" X="0.000*mm" Y="61.000*mm" Z="799.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                        </modules>
+                        <moduleProperties modLength="41.000*mm" modWidth="25.600*mm" modThickness="1.434*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.187*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.029*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.086*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="0.602*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.430*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="41.000*mm" sensorWidth="25.600*mm" sensorThickness="0.100*mm" resRPhi="7.5*um" resZ="15.0*um"/>
+                    </rodOdd>
+                    <rodEven id="2">
+                        <modules>
+                            <module id="1" X="-22.578*mm" Y="54.509*mm" Z="-799.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="2" X="-22.578*mm" Y="54.509*mm" Z="-758.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="3" X="-22.578*mm" Y="54.509*mm" Z="-717.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="4" X="-22.578*mm" Y="54.509*mm" Z="-676.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="5" X="-22.578*mm" Y="54.509*mm" Z="-635.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="6" X="-22.578*mm" Y="54.509*mm" Z="-594.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="7" X="-22.578*mm" Y="54.509*mm" Z="-553.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="8" X="-22.578*mm" Y="54.509*mm" Z="-512.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="9" X="-22.578*mm" Y="54.509*mm" Z="-471.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="10" X="-22.578*mm" Y="54.509*mm" Z="-430.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="11" X="-22.578*mm" Y="54.509*mm" Z="-389.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="12" X="-22.578*mm" Y="54.509*mm" Z="-348.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="13" X="-22.578*mm" Y="54.509*mm" Z="-307.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="14" X="-22.578*mm" Y="54.509*mm" Z="-266.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="15" X="-22.578*mm" Y="54.509*mm" Z="-225.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="16" X="-22.578*mm" Y="54.509*mm" Z="-184.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="17" X="-22.578*mm" Y="54.509*mm" Z="-143.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="18" X="-22.578*mm" Y="54.509*mm" Z="-102.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="19" X="-22.578*mm" Y="54.509*mm" Z="-61.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="20" X="-22.578*mm" Y="54.509*mm" Z="-20.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="21" X="-22.578*mm" Y="54.509*mm" Z="20.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="22" X="-22.578*mm" Y="54.509*mm" Z="61.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="23" X="-22.578*mm" Y="54.509*mm" Z="102.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="24" X="-22.578*mm" Y="54.509*mm" Z="143.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="25" X="-22.578*mm" Y="54.509*mm" Z="184.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="26" X="-22.578*mm" Y="54.509*mm" Z="225.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="27" X="-22.578*mm" Y="54.509*mm" Z="266.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="28" X="-22.578*mm" Y="54.509*mm" Z="307.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="29" X="-22.578*mm" Y="54.509*mm" Z="348.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="30" X="-22.578*mm" Y="54.509*mm" Z="389.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="31" X="-22.578*mm" Y="54.509*mm" Z="430.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="32" X="-22.578*mm" Y="54.509*mm" Z="471.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="33" X="-22.578*mm" Y="54.509*mm" Z="512.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="34" X="-22.578*mm" Y="54.509*mm" Z="553.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="35" X="-22.578*mm" Y="54.509*mm" Z="594.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="36" X="-22.578*mm" Y="54.509*mm" Z="635.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="37" X="-22.578*mm" Y="54.509*mm" Z="676.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="38" X="-22.578*mm" Y="54.509*mm" Z="717.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="39" X="-22.578*mm" Y="54.509*mm" Z="758.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="40" X="-22.578*mm" Y="54.509*mm" Z="799.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                        </modules>
+                        <moduleProperties modLength="41.000*mm" modWidth="25.600*mm" modThickness="1.434*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.187*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.029*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.086*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="0.602*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.430*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="41.000*mm" sensorWidth="25.600*mm" sensorThickness="0.100*mm" resRPhi="7.5*um" resZ="15.0*um"/>
+                    </rodEven>
+                </rods>
+            </layer>
+            <layer id="3" radius="100.000*mm" rmin="98.283*mm" rmax="102.519*mm" bigDelta="1.000*mm" phi0="1.570796*rad">
+                <rods repeat="26" smallDelta="0.000*mm" rPhiOverlap="0.000*mm" nRPhiSegments="2" zOverlap="0.000*mm" nModules="40">
+                    <rodOdd id="1">
+                        <modules>
+                            <module id="1" X="0.000*mm" Y="101.000*mm" Z="-799.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="2" X="0.000*mm" Y="101.000*mm" Z="-758.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="3" X="0.000*mm" Y="101.000*mm" Z="-717.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="4" X="0.000*mm" Y="101.000*mm" Z="-676.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="5" X="0.000*mm" Y="101.000*mm" Z="-635.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="6" X="0.000*mm" Y="101.000*mm" Z="-594.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="7" X="0.000*mm" Y="101.000*mm" Z="-553.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="8" X="0.000*mm" Y="101.000*mm" Z="-512.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="9" X="0.000*mm" Y="101.000*mm" Z="-471.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="10" X="0.000*mm" Y="101.000*mm" Z="-430.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="11" X="0.000*mm" Y="101.000*mm" Z="-389.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="12" X="0.000*mm" Y="101.000*mm" Z="-348.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="13" X="0.000*mm" Y="101.000*mm" Z="-307.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="14" X="0.000*mm" Y="101.000*mm" Z="-266.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="15" X="0.000*mm" Y="101.000*mm" Z="-225.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="16" X="0.000*mm" Y="101.000*mm" Z="-184.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="17" X="0.000*mm" Y="101.000*mm" Z="-143.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="18" X="0.000*mm" Y="101.000*mm" Z="-102.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="19" X="0.000*mm" Y="101.000*mm" Z="-61.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="20" X="0.000*mm" Y="101.000*mm" Z="-20.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="21" X="0.000*mm" Y="101.000*mm" Z="20.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="22" X="0.000*mm" Y="101.000*mm" Z="61.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="23" X="0.000*mm" Y="101.000*mm" Z="102.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="24" X="0.000*mm" Y="101.000*mm" Z="143.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="25" X="0.000*mm" Y="101.000*mm" Z="184.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="26" X="0.000*mm" Y="101.000*mm" Z="225.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="27" X="0.000*mm" Y="101.000*mm" Z="266.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="28" X="0.000*mm" Y="101.000*mm" Z="307.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="29" X="0.000*mm" Y="101.000*mm" Z="348.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="30" X="0.000*mm" Y="101.000*mm" Z="389.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="31" X="0.000*mm" Y="101.000*mm" Z="430.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="32" X="0.000*mm" Y="101.000*mm" Z="471.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="33" X="0.000*mm" Y="101.000*mm" Z="512.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="34" X="0.000*mm" Y="101.000*mm" Z="553.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="35" X="0.000*mm" Y="101.000*mm" Z="594.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="36" X="0.000*mm" Y="101.000*mm" Z="635.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="37" X="0.000*mm" Y="101.000*mm" Z="676.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="38" X="0.000*mm" Y="101.000*mm" Z="717.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="39" X="0.000*mm" Y="101.000*mm" Z="758.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="40" X="0.000*mm" Y="101.000*mm" Z="799.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                        </modules>
+                        <moduleProperties modLength="41.000*mm" modWidth="25.600*mm" modThickness="1.434*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.187*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.029*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.086*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="0.602*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.430*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="41.000*mm" sensorWidth="25.600*mm" sensorThickness="0.100*mm" resRPhi="7.5*um" resZ="15.0*um"/>
+                    </rodOdd>
+                    <rodEven id="2">
+                        <modules>
+                            <module id="1" X="-23.692*mm" Y="96.123*mm" Z="-799.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="2" X="-23.692*mm" Y="96.123*mm" Z="-758.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="3" X="-23.692*mm" Y="96.123*mm" Z="-717.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="4" X="-23.692*mm" Y="96.123*mm" Z="-676.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="5" X="-23.692*mm" Y="96.123*mm" Z="-635.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="6" X="-23.692*mm" Y="96.123*mm" Z="-594.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="7" X="-23.692*mm" Y="96.123*mm" Z="-553.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="8" X="-23.692*mm" Y="96.123*mm" Z="-512.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="9" X="-23.692*mm" Y="96.123*mm" Z="-471.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="10" X="-23.692*mm" Y="96.123*mm" Z="-430.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="11" X="-23.692*mm" Y="96.123*mm" Z="-389.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="12" X="-23.692*mm" Y="96.123*mm" Z="-348.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="13" X="-23.692*mm" Y="96.123*mm" Z="-307.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="14" X="-23.692*mm" Y="96.123*mm" Z="-266.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="15" X="-23.692*mm" Y="96.123*mm" Z="-225.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="16" X="-23.692*mm" Y="96.123*mm" Z="-184.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="17" X="-23.692*mm" Y="96.123*mm" Z="-143.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="18" X="-23.692*mm" Y="96.123*mm" Z="-102.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="19" X="-23.692*mm" Y="96.123*mm" Z="-61.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="20" X="-23.692*mm" Y="96.123*mm" Z="-20.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="21" X="-23.692*mm" Y="96.123*mm" Z="20.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="22" X="-23.692*mm" Y="96.123*mm" Z="61.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="23" X="-23.692*mm" Y="96.123*mm" Z="102.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="24" X="-23.692*mm" Y="96.123*mm" Z="143.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="25" X="-23.692*mm" Y="96.123*mm" Z="184.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="26" X="-23.692*mm" Y="96.123*mm" Z="225.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="27" X="-23.692*mm" Y="96.123*mm" Z="266.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="28" X="-23.692*mm" Y="96.123*mm" Z="307.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="29" X="-23.692*mm" Y="96.123*mm" Z="348.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="30" X="-23.692*mm" Y="96.123*mm" Z="389.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="31" X="-23.692*mm" Y="96.123*mm" Z="430.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="32" X="-23.692*mm" Y="96.123*mm" Z="471.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="33" X="-23.692*mm" Y="96.123*mm" Z="512.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="34" X="-23.692*mm" Y="96.123*mm" Z="553.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="35" X="-23.692*mm" Y="96.123*mm" Z="594.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="36" X="-23.692*mm" Y="96.123*mm" Z="635.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="37" X="-23.692*mm" Y="96.123*mm" Z="676.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="38" X="-23.692*mm" Y="96.123*mm" Z="717.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="39" X="-23.692*mm" Y="96.123*mm" Z="758.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="40" X="-23.692*mm" Y="96.123*mm" Z="799.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                        </modules>
+                        <moduleProperties modLength="41.000*mm" modWidth="25.600*mm" modThickness="1.434*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.187*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.029*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.086*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="0.602*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.430*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="41.000*mm" sensorWidth="25.600*mm" sensorThickness="0.100*mm" resRPhi="7.5*um" resZ="15.0*um"/>
+                    </rodEven>
+                </rods>
+            </layer>
+            <layer id="4" radius="150.000*mm" rmin="148.283*mm" rmax="152.256*mm" bigDelta="1.000*mm" phi0="1.570796*rad">
+                <rods repeat="38" smallDelta="0.000*mm" rPhiOverlap="0.000*mm" nRPhiSegments="2" zOverlap="0.000*mm" nModules="40">
+                    <rodOdd id="1">
+                        <modules>
+                            <module id="1" X="0.000*mm" Y="151.000*mm" Z="-799.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="2" X="0.000*mm" Y="151.000*mm" Z="-758.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="3" X="0.000*mm" Y="151.000*mm" Z="-717.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="4" X="0.000*mm" Y="151.000*mm" Z="-676.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="5" X="0.000*mm" Y="151.000*mm" Z="-635.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="6" X="0.000*mm" Y="151.000*mm" Z="-594.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="7" X="0.000*mm" Y="151.000*mm" Z="-553.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="8" X="0.000*mm" Y="151.000*mm" Z="-512.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="9" X="0.000*mm" Y="151.000*mm" Z="-471.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="10" X="0.000*mm" Y="151.000*mm" Z="-430.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="11" X="0.000*mm" Y="151.000*mm" Z="-389.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="12" X="0.000*mm" Y="151.000*mm" Z="-348.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="13" X="0.000*mm" Y="151.000*mm" Z="-307.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="14" X="0.000*mm" Y="151.000*mm" Z="-266.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="15" X="0.000*mm" Y="151.000*mm" Z="-225.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="16" X="0.000*mm" Y="151.000*mm" Z="-184.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="17" X="0.000*mm" Y="151.000*mm" Z="-143.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="18" X="0.000*mm" Y="151.000*mm" Z="-102.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="19" X="0.000*mm" Y="151.000*mm" Z="-61.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="20" X="0.000*mm" Y="151.000*mm" Z="-20.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="21" X="0.000*mm" Y="151.000*mm" Z="20.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="22" X="0.000*mm" Y="151.000*mm" Z="61.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="23" X="0.000*mm" Y="151.000*mm" Z="102.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="24" X="0.000*mm" Y="151.000*mm" Z="143.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="25" X="0.000*mm" Y="151.000*mm" Z="184.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="26" X="0.000*mm" Y="151.000*mm" Z="225.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="27" X="0.000*mm" Y="151.000*mm" Z="266.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="28" X="0.000*mm" Y="151.000*mm" Z="307.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="29" X="0.000*mm" Y="151.000*mm" Z="348.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="30" X="0.000*mm" Y="151.000*mm" Z="389.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="31" X="0.000*mm" Y="151.000*mm" Z="430.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="32" X="0.000*mm" Y="151.000*mm" Z="471.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="33" X="0.000*mm" Y="151.000*mm" Z="512.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="34" X="0.000*mm" Y="151.000*mm" Z="553.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="35" X="0.000*mm" Y="151.000*mm" Z="594.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="36" X="0.000*mm" Y="151.000*mm" Z="635.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="37" X="0.000*mm" Y="151.000*mm" Z="676.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="38" X="0.000*mm" Y="151.000*mm" Z="717.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="39" X="0.000*mm" Y="151.000*mm" Z="758.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="40" X="0.000*mm" Y="151.000*mm" Z="799.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                        </modules>
+                        <moduleProperties modLength="41.000*mm" modWidth="25.600*mm" modThickness="1.434*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.187*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.029*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.086*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="0.602*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.430*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="41.000*mm" sensorWidth="25.600*mm" sensorThickness="0.100*mm" resRPhi="7.5*um" resZ="15.0*um"/>
+                    </rodOdd>
+                    <rodEven id="2">
+                        <modules>
+                            <module id="1" X="-24.525*mm" Y="146.968*mm" Z="-799.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="2" X="-24.525*mm" Y="146.968*mm" Z="-758.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="3" X="-24.525*mm" Y="146.968*mm" Z="-717.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="4" X="-24.525*mm" Y="146.968*mm" Z="-676.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="5" X="-24.525*mm" Y="146.968*mm" Z="-635.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="6" X="-24.525*mm" Y="146.968*mm" Z="-594.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="7" X="-24.525*mm" Y="146.968*mm" Z="-553.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="8" X="-24.525*mm" Y="146.968*mm" Z="-512.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="9" X="-24.525*mm" Y="146.968*mm" Z="-471.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="10" X="-24.525*mm" Y="146.968*mm" Z="-430.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="11" X="-24.525*mm" Y="146.968*mm" Z="-389.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="12" X="-24.525*mm" Y="146.968*mm" Z="-348.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="13" X="-24.525*mm" Y="146.968*mm" Z="-307.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="14" X="-24.525*mm" Y="146.968*mm" Z="-266.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="15" X="-24.525*mm" Y="146.968*mm" Z="-225.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="16" X="-24.525*mm" Y="146.968*mm" Z="-184.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="17" X="-24.525*mm" Y="146.968*mm" Z="-143.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="18" X="-24.525*mm" Y="146.968*mm" Z="-102.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="19" X="-24.525*mm" Y="146.968*mm" Z="-61.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="20" X="-24.525*mm" Y="146.968*mm" Z="-20.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="21" X="-24.525*mm" Y="146.968*mm" Z="20.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="22" X="-24.525*mm" Y="146.968*mm" Z="61.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="23" X="-24.525*mm" Y="146.968*mm" Z="102.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="24" X="-24.525*mm" Y="146.968*mm" Z="143.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="25" X="-24.525*mm" Y="146.968*mm" Z="184.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="26" X="-24.525*mm" Y="146.968*mm" Z="225.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="27" X="-24.525*mm" Y="146.968*mm" Z="266.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="28" X="-24.525*mm" Y="146.968*mm" Z="307.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="29" X="-24.525*mm" Y="146.968*mm" Z="348.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="30" X="-24.525*mm" Y="146.968*mm" Z="389.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="31" X="-24.525*mm" Y="146.968*mm" Z="430.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="32" X="-24.525*mm" Y="146.968*mm" Z="471.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="33" X="-24.525*mm" Y="146.968*mm" Z="512.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="34" X="-24.525*mm" Y="146.968*mm" Z="553.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="35" X="-24.525*mm" Y="146.968*mm" Z="594.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="36" X="-24.525*mm" Y="146.968*mm" Z="635.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="37" X="-24.525*mm" Y="146.968*mm" Z="676.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="38" X="-24.525*mm" Y="146.968*mm" Z="717.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="39" X="-24.525*mm" Y="146.968*mm" Z="758.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="40" X="-24.525*mm" Y="146.968*mm" Z="799.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                        </modules>
+                        <moduleProperties modLength="41.000*mm" modWidth="25.600*mm" modThickness="1.434*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.187*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.029*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.086*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="0.602*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.430*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="41.000*mm" sensorWidth="25.600*mm" sensorThickness="0.100*mm" resRPhi="7.5*um" resZ="15.0*um"/>
+                    </rodEven>
+                </rods>
+            </layer>
+        </layers>
+    </detector>
+    <detector name="InnerBRL_1" id="BarTrackerInner_id + 16" type="TkLayoutBrlTracker" readout="TrackerBarrelReadout">
+        <dimensions rmin="261.066*mm" rmax="409.734*mm" zmin="-820.000*mm" zmax="820.000*mm"/>
+        <sensitive type="SimpleTrackerSD"/>
+        <layers repeat="2">
+            <layer id="1" radius="270.000*mm" rmin="261.066*mm" rmax="280.106*mm" bigDelta="5.000*mm" phi0="1.570796*rad">
+                <rods repeat="34" smallDelta="2.500*mm" rPhiOverlap="0.000*mm" nRPhiSegments="2" zOverlap="0.000*mm" nModules="17">
+                    <rodOdd id="1">
+                        <modules>
+                            <module id="1" X="0.000*mm" Y="272.500*mm" Z="-768.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="2" X="0.000*mm" Y="277.500*mm" Z="-687.843*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="3" X="0.000*mm" Y="272.500*mm" Z="-580.649*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="4" X="0.000*mm" Y="277.500*mm" Z="-494.917*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="5" X="0.000*mm" Y="272.500*mm" Z="-389.824*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="6" X="0.000*mm" Y="277.500*mm" Z="-299.250*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="7" X="0.000*mm" Y="272.500*mm" Z="-196.287*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="8" X="0.000*mm" Y="277.500*mm" Z="-100.802*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="9" X="0.000*mm" Y="272.500*mm" Z="0.000*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="10" X="0.000*mm" Y="277.500*mm" Z="100.802*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="11" X="0.000*mm" Y="272.500*mm" Z="196.287*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="12" X="0.000*mm" Y="277.500*mm" Z="299.250*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="13" X="0.000*mm" Y="272.500*mm" Z="389.824*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="14" X="0.000*mm" Y="277.500*mm" Z="494.917*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="15" X="0.000*mm" Y="272.500*mm" Z="580.649*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="16" X="0.000*mm" Y="277.500*mm" Z="687.843*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="17" X="0.000*mm" Y="272.500*mm" Z="768.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidth="51.200*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidth="51.200*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </rodOdd>
+                    <rodEven id="2">
+                        <modules>
+                            <module id="1" X="-48.234*mm" Y="258.030*mm" Z="-768.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="2" X="-49.153*mm" Y="262.945*mm" Z="-687.843*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="3" X="-48.234*mm" Y="258.030*mm" Z="-580.649*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="4" X="-49.153*mm" Y="262.945*mm" Z="-494.917*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="5" X="-48.234*mm" Y="258.030*mm" Z="-389.824*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="6" X="-49.153*mm" Y="262.945*mm" Z="-299.250*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="7" X="-48.234*mm" Y="258.030*mm" Z="-196.287*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="8" X="-49.153*mm" Y="262.945*mm" Z="-100.802*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="9" X="-48.234*mm" Y="258.030*mm" Z="0.000*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="10" X="-49.153*mm" Y="262.945*mm" Z="100.802*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="11" X="-48.234*mm" Y="258.030*mm" Z="196.287*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="12" X="-49.153*mm" Y="262.945*mm" Z="299.250*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="13" X="-48.234*mm" Y="258.030*mm" Z="389.824*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="14" X="-49.153*mm" Y="262.945*mm" Z="494.917*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="15" X="-48.234*mm" Y="258.030*mm" Z="580.649*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="16" X="-49.153*mm" Y="262.945*mm" Z="687.843*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="17" X="-48.234*mm" Y="258.030*mm" Z="768.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidth="51.200*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidth="51.200*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </rodEven>
+                </rods>
+            </layer>
+            <layer id="2" radius="400.000*mm" rmin="391.066*mm" rmax="409.734*mm" bigDelta="5.000*mm" phi0="1.570796*rad">
+                <rods repeat="50" smallDelta="2.500*mm" rPhiOverlap="0.000*mm" nRPhiSegments="2" zOverlap="0.000*mm" nModules="17">
+                    <rodOdd id="1">
+                        <modules>
+                            <module id="1" X="0.000*mm" Y="402.500*mm" Z="-768.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="2" X="0.000*mm" Y="407.500*mm" Z="-687.843*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="3" X="0.000*mm" Y="402.500*mm" Z="-580.649*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="4" X="0.000*mm" Y="407.500*mm" Z="-494.917*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="5" X="0.000*mm" Y="402.500*mm" Z="-389.824*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="6" X="0.000*mm" Y="407.500*mm" Z="-299.250*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="7" X="0.000*mm" Y="402.500*mm" Z="-196.287*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="8" X="0.000*mm" Y="407.500*mm" Z="-100.802*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="9" X="0.000*mm" Y="402.500*mm" Z="0.000*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="10" X="0.000*mm" Y="407.500*mm" Z="100.802*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="11" X="0.000*mm" Y="402.500*mm" Z="196.287*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="12" X="0.000*mm" Y="407.500*mm" Z="299.250*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="13" X="0.000*mm" Y="402.500*mm" Z="389.824*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="14" X="0.000*mm" Y="407.500*mm" Z="494.917*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="15" X="0.000*mm" Y="402.500*mm" Z="580.649*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="16" X="0.000*mm" Y="407.500*mm" Z="687.843*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="17" X="0.000*mm" Y="402.500*mm" Z="768.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidth="51.200*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidth="51.200*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </rodOdd>
+                    <rodEven id="2">
+                        <modules>
+                            <module id="1" X="-49.193*mm" Y="389.405*mm" Z="-768.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="2" X="-49.820*mm" Y="394.366*mm" Z="-687.843*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="3" X="-49.193*mm" Y="389.405*mm" Z="-580.649*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="4" X="-49.820*mm" Y="394.366*mm" Z="-494.917*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="5" X="-49.193*mm" Y="389.405*mm" Z="-389.824*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="6" X="-49.820*mm" Y="394.366*mm" Z="-299.250*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="7" X="-49.193*mm" Y="389.405*mm" Z="-196.287*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="8" X="-49.820*mm" Y="394.366*mm" Z="-100.802*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="9" X="-49.193*mm" Y="389.405*mm" Z="0.000*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="10" X="-49.820*mm" Y="394.366*mm" Z="100.802*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="11" X="-49.193*mm" Y="389.405*mm" Z="196.287*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="12" X="-49.820*mm" Y="394.366*mm" Z="299.250*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="13" X="-49.193*mm" Y="389.405*mm" Z="389.824*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="14" X="-49.820*mm" Y="394.366*mm" Z="494.917*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="15" X="-49.193*mm" Y="389.405*mm" Z="580.649*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="16" X="-49.820*mm" Y="394.366*mm" Z="687.843*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="17" X="-49.193*mm" Y="389.405*mm" Z="768.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidth="51.200*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidth="51.200*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </rodEven>
+                </rods>
+            </layer>
+        </layers>
+    </detector>
+    <detector name="InnerECAPpos" id="EndCapTrackerInner_id" type="TkLayoutEcapTracker" readout="TrackerEndcapReadout">
+        <dimensions rmin="25.000*mm" rmax="403.728*mm" zmin="941.066*mm" zmax="2258.934*mm" reflect="false"/>
+        <sensitive type="SimpleTrackerSD"/>
+        <discs repeat="10">
+            <discZPls id="1" z="950.000*mm" zmin="941.066*mm" zmax="958.934*mm" rmin="25.000*mm" rmax="403.728*mm" bigDelta="5.000*mm">
+                <rings repeat="4" smallDelta="2.500*mm" rPhiOverlap="0.000*mm" nRPhiSegments="4" rOverlap="0.000*mm">
+                    <ring id="1" phi0="0.000000*rad" nModules="12">
+                        <modules>
+                            <moduleOdd id="1" X="63.049*mm" Y="0.000*mm" Z="942.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="54.602*mm" Y="31.525*mm" Z="947.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="76.099*mm" modWidthMin="13.397*mm" modWidthMax="54.179*mm" modThickness="2.150*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.330*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.043*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.129*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="0.903*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.645*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="76.099*mm" sensorWidthMin="13.397*mm" sensorWidthMax="54.179*mm" sensorThickness="0.100*mm" resRPhi="7.5*um" resZ="15.0*um"/>
+                    </ring>
+                    <ring id="2" phi0="0.000000*rad" nModules="20">
+                        <modules>
+                            <moduleOdd id="1" X="151.685*mm" Y="0.000*mm" Z="952.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="144.261*mm" Y="46.873*mm" Z="957.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="100.736*mm" modWidthMin="32.094*mm" modWidthMax="64.004*mm" modThickness="2.150*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.330*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.043*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.129*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="0.903*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.645*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="100.736*mm" sensorWidthMin="32.094*mm" sensorWidthMax="64.004*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="30.0*um"/>
+                    </ring>
+                    <ring id="3" phi0="0.000000*rad" nModules="32">
+                        <modules>
+                            <moduleOdd id="1" X="250.156*mm" Y="0.000*mm" Z="942.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="245.349*mm" Y="48.803*mm" Z="947.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="103.074*mm" modWidthMin="39.124*mm" modWidthMax="59.428*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="103.074*mm" sensorWidthMin="39.124*mm" sensorWidthMax="59.428*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="4" phi0="0.000000*rad" nModules="44">
+                        <modules>
+                            <moduleOdd id="1" X="352.521*mm" Y="0.000*mm" Z="952.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="348.933*mm" Y="50.169*mm" Z="957.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="100.357*mm" modWidthMin="43.248*mm" modWidthMax="57.603*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="100.357*mm" sensorWidthMin="43.248*mm" sensorWidthMax="57.603*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                </rings>
+            </discZPls>
+            <discZPls id="2" z="1178.524*mm" zmin="1169.590*mm" zmax="1187.457*mm" rmin="25.000*mm" rmax="403.728*mm" bigDelta="5.000*mm">
+                <rings repeat="4" smallDelta="2.500*mm" rPhiOverlap="0.000*mm" nRPhiSegments="4" rOverlap="0.000*mm"/>
+            </discZPls>
+            <discZPls id="3" z="1462.019*mm" zmin="1453.085*mm" zmax="1470.953*mm" rmin="25.000*mm" rmax="403.728*mm" bigDelta="5.000*mm">
+                <rings repeat="4" smallDelta="2.500*mm" rPhiOverlap="0.000*mm" nRPhiSegments="4" rOverlap="0.000*mm"/>
+            </discZPls>
+            <discZPls id="4" z="1813.710*mm" zmin="1804.776*mm" zmax="1822.643*mm" rmin="25.000*mm" rmax="403.728*mm" bigDelta="5.000*mm">
+                <rings repeat="4" smallDelta="2.500*mm" rPhiOverlap="0.000*mm" nRPhiSegments="4" rOverlap="0.000*mm"/>
+            </discZPls>
+            <discZPls id="5" z="2250.000*mm" zmin="2241.066*mm" zmax="2258.934*mm" rmin="25.000*mm" rmax="403.728*mm" bigDelta="5.000*mm">
+                <rings repeat="4" smallDelta="2.500*mm" rPhiOverlap="0.000*mm" nRPhiSegments="4" rOverlap="0.000*mm"/>
+            </discZPls>
+        </discs>
+    </detector>
+    <detector name="InnerECAPneg" id="EndCapTrackerInner_id + 16" type="TkLayoutEcapTracker" readout="TrackerEndcapReadout">
+        <dimensions rmin="25.000*mm" rmax="403.728*mm" zmin="941.066*mm" zmax="2258.934*mm" reflect="true"/>
+        <sensitive type="SimpleTrackerSD"/>
+        <discs repeat="10">
+            <discZPls id="1" z="950.000*mm" zmin="941.066*mm" zmax="958.934*mm" rmin="25.000*mm" rmax="403.728*mm" bigDelta="5.000*mm">
+                <rings repeat="4" smallDelta="2.500*mm" rPhiOverlap="0.000*mm" nRPhiSegments="4" rOverlap="0.000*mm">
+                    <ring id="1" phi0="0.000000*rad" nModules="12">
+                        <modules>
+                            <moduleOdd id="1" X="63.049*mm" Y="0.000*mm" Z="942.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="54.602*mm" Y="31.525*mm" Z="947.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="76.099*mm" modWidthMin="13.397*mm" modWidthMax="54.179*mm" modThickness="2.150*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.330*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.043*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.129*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="0.903*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.645*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="76.099*mm" sensorWidthMin="13.397*mm" sensorWidthMax="54.179*mm" sensorThickness="0.100*mm" resRPhi="7.5*um" resZ="15.0*um"/>
+                    </ring>
+                    <ring id="2" phi0="0.000000*rad" nModules="20">
+                        <modules>
+                            <moduleOdd id="1" X="151.685*mm" Y="0.000*mm" Z="952.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="144.261*mm" Y="46.873*mm" Z="957.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="100.736*mm" modWidthMin="32.094*mm" modWidthMax="64.004*mm" modThickness="2.150*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.330*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.043*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.129*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="0.903*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.645*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="100.736*mm" sensorWidthMin="32.094*mm" sensorWidthMax="64.004*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="30.0*um"/>
+                    </ring>
+                    <ring id="3" phi0="0.000000*rad" nModules="32">
+                        <modules>
+                            <moduleOdd id="1" X="250.156*mm" Y="0.000*mm" Z="942.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="245.349*mm" Y="48.803*mm" Z="947.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="103.074*mm" modWidthMin="39.124*mm" modWidthMax="59.428*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="103.074*mm" sensorWidthMin="39.124*mm" sensorWidthMax="59.428*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="4" phi0="0.000000*rad" nModules="44">
+                        <modules>
+                            <moduleOdd id="1" X="352.521*mm" Y="0.000*mm" Z="952.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="348.933*mm" Y="50.169*mm" Z="957.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="100.357*mm" modWidthMin="43.248*mm" modWidthMax="57.603*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="100.357*mm" sensorWidthMin="43.248*mm" sensorWidthMax="57.603*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                </rings>
+            </discZPls>
+            <discZPls id="2" z="1178.524*mm" zmin="1169.590*mm" zmax="1187.457*mm" rmin="25.000*mm" rmax="403.728*mm" bigDelta="5.000*mm">
+                <rings repeat="4" smallDelta="2.500*mm" rPhiOverlap="0.000*mm" nRPhiSegments="4" rOverlap="0.000*mm"/>
+            </discZPls>
+            <discZPls id="3" z="1462.019*mm" zmin="1453.085*mm" zmax="1470.953*mm" rmin="25.000*mm" rmax="403.728*mm" bigDelta="5.000*mm">
+                <rings repeat="4" smallDelta="2.500*mm" rPhiOverlap="0.000*mm" nRPhiSegments="4" rOverlap="0.000*mm"/>
+            </discZPls>
+            <discZPls id="4" z="1813.710*mm" zmin="1804.776*mm" zmax="1822.643*mm" rmin="25.000*mm" rmax="403.728*mm" bigDelta="5.000*mm">
+                <rings repeat="4" smallDelta="2.500*mm" rPhiOverlap="0.000*mm" nRPhiSegments="4" rOverlap="0.000*mm"/>
+            </discZPls>
+            <discZPls id="5" z="2250.000*mm" zmin="2241.066*mm" zmax="2258.934*mm" rmin="25.000*mm" rmax="403.728*mm" bigDelta="5.000*mm">
+                <rings repeat="4" smallDelta="2.500*mm" rPhiOverlap="0.000*mm" nRPhiSegments="4" rOverlap="0.000*mm"/>
+            </discZPls>
+        </discs>
+    </detector>
+    <detector name="OuterBRL" id="BarTrackerOuter_id" type="TkLayoutBrlTracker" readout="TrackerBarrelReadout">
+        <dimensions rmin="521.016*mm" rmax="1526.688*mm" zmin="-2250.000*mm" zmax="2250.000*mm"/>
+        <sensitive type="SimpleTrackerSD"/>
+        <layers repeat="6">
+            <layer id="1" radius="529.950*mm" rmin="521.016*mm" rmax="541.311*mm" bigDelta="5.000*mm" phi0="1.570796*rad">
+                <rods repeat="34" smallDelta="2.500*mm" rPhiOverlap="0.500*mm" nRPhiSegments="2" zOverlap="0.750*mm" nModules="47">
+                    <rodOdd id="1">
+                        <modules>
+                            <module id="1" X="0.000*mm" Y="532.450*mm" Z="-2198.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="2" X="0.000*mm" Y="537.450*mm" Z="-2119.978*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="3" X="0.000*mm" Y="532.450*mm" Z="-2013.801*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="4" X="0.000*mm" Y="537.450*mm" Z="-1933.208*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="5" X="0.000*mm" Y="532.450*mm" Z="-1827.643*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="6" X="0.000*mm" Y="537.450*mm" Z="-1745.269*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="7" X="0.000*mm" Y="532.450*mm" Z="-1640.321*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="8" X="0.000*mm" Y="537.450*mm" Z="-1556.154*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="9" X="0.000*mm" Y="532.450*mm" Z="-1451.827*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="10" X="0.000*mm" Y="537.450*mm" Z="-1365.856*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="11" X="0.000*mm" Y="532.450*mm" Z="-1262.153*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="12" X="0.000*mm" Y="537.450*mm" Z="-1174.366*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="13" X="0.000*mm" Y="532.450*mm" Z="-1071.292*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="14" X="0.000*mm" Y="537.450*mm" Z="-981.679*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="15" X="0.000*mm" Y="532.450*mm" Z="-879.236*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="16" X="0.000*mm" Y="537.450*mm" Z="-787.785*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="17" X="0.000*mm" Y="532.450*mm" Z="-685.978*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="18" X="0.000*mm" Y="537.450*mm" Z="-592.678*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="19" X="0.000*mm" Y="532.450*mm" Z="-491.511*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="20" X="0.000*mm" Y="537.450*mm" Z="-396.350*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="21" X="0.000*mm" Y="532.450*mm" Z="-295.827*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="22" X="0.000*mm" Y="537.450*mm" Z="-198.793*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="23" X="0.000*mm" Y="532.450*mm" Z="-98.919*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="24" X="0.000*mm" Y="537.450*mm" Z="0.000*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="25" X="0.000*mm" Y="532.450*mm" Z="98.919*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="26" X="0.000*mm" Y="537.450*mm" Z="198.793*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="27" X="0.000*mm" Y="532.450*mm" Z="295.827*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="28" X="0.000*mm" Y="537.450*mm" Z="396.350*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="29" X="0.000*mm" Y="532.450*mm" Z="491.511*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="30" X="0.000*mm" Y="537.450*mm" Z="592.678*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="31" X="0.000*mm" Y="532.450*mm" Z="685.978*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="32" X="0.000*mm" Y="537.450*mm" Z="787.785*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="33" X="0.000*mm" Y="532.450*mm" Z="879.236*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="34" X="0.000*mm" Y="537.450*mm" Z="981.679*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="35" X="0.000*mm" Y="532.450*mm" Z="1071.292*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="36" X="0.000*mm" Y="537.450*mm" Z="1174.366*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="37" X="0.000*mm" Y="532.450*mm" Z="1262.153*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="38" X="0.000*mm" Y="537.450*mm" Z="1365.856*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="39" X="0.000*mm" Y="532.450*mm" Z="1451.827*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="40" X="0.000*mm" Y="537.450*mm" Z="1556.154*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="41" X="0.000*mm" Y="532.450*mm" Z="1640.321*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="42" X="0.000*mm" Y="537.450*mm" Z="1745.269*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="43" X="0.000*mm" Y="532.450*mm" Z="1827.643*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="44" X="0.000*mm" Y="537.450*mm" Z="1933.208*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="45" X="0.000*mm" Y="532.450*mm" Z="2013.801*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="46" X="0.000*mm" Y="537.450*mm" Z="2119.978*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="47" X="0.000*mm" Y="532.450*mm" Z="2198.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidth="102.400*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidth="102.400*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </rodOdd>
+                    <rodEven id="2">
+                        <modules>
+                            <module id="1" X="-96.000*mm" Y="513.554*mm" Z="-2198.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="2" X="-96.919*mm" Y="518.469*mm" Z="-2119.978*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="3" X="-96.000*mm" Y="513.554*mm" Z="-2013.801*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="4" X="-96.919*mm" Y="518.469*mm" Z="-1933.208*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="5" X="-96.000*mm" Y="513.554*mm" Z="-1827.643*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="6" X="-96.919*mm" Y="518.469*mm" Z="-1745.269*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="7" X="-96.000*mm" Y="513.554*mm" Z="-1640.321*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="8" X="-96.919*mm" Y="518.469*mm" Z="-1556.154*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="9" X="-96.000*mm" Y="513.554*mm" Z="-1451.827*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="10" X="-96.919*mm" Y="518.469*mm" Z="-1365.856*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="11" X="-96.000*mm" Y="513.554*mm" Z="-1262.153*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="12" X="-96.919*mm" Y="518.469*mm" Z="-1174.366*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="13" X="-96.000*mm" Y="513.554*mm" Z="-1071.292*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="14" X="-96.919*mm" Y="518.469*mm" Z="-981.679*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="15" X="-96.000*mm" Y="513.554*mm" Z="-879.236*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="16" X="-96.919*mm" Y="518.469*mm" Z="-787.785*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="17" X="-96.000*mm" Y="513.554*mm" Z="-685.978*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="18" X="-96.919*mm" Y="518.469*mm" Z="-592.678*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="19" X="-96.000*mm" Y="513.554*mm" Z="-491.511*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="20" X="-96.919*mm" Y="518.469*mm" Z="-396.350*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="21" X="-96.000*mm" Y="513.554*mm" Z="-295.827*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="22" X="-96.919*mm" Y="518.469*mm" Z="-198.793*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="23" X="-96.000*mm" Y="513.554*mm" Z="-98.919*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="24" X="-96.919*mm" Y="518.469*mm" Z="0.000*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="25" X="-96.000*mm" Y="513.554*mm" Z="98.919*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="26" X="-96.919*mm" Y="518.469*mm" Z="198.793*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="27" X="-96.000*mm" Y="513.554*mm" Z="295.827*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="28" X="-96.919*mm" Y="518.469*mm" Z="396.350*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="29" X="-96.000*mm" Y="513.554*mm" Z="491.511*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="30" X="-96.919*mm" Y="518.469*mm" Z="592.678*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="31" X="-96.000*mm" Y="513.554*mm" Z="685.978*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="32" X="-96.919*mm" Y="518.469*mm" Z="787.785*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="33" X="-96.000*mm" Y="513.554*mm" Z="879.236*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="34" X="-96.919*mm" Y="518.469*mm" Z="981.679*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="35" X="-96.000*mm" Y="513.554*mm" Z="1071.292*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="36" X="-96.919*mm" Y="518.469*mm" Z="1174.366*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="37" X="-96.000*mm" Y="513.554*mm" Z="1262.153*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="38" X="-96.919*mm" Y="518.469*mm" Z="1365.856*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="39" X="-96.000*mm" Y="513.554*mm" Z="1451.827*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="40" X="-96.919*mm" Y="518.469*mm" Z="1556.154*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="41" X="-96.000*mm" Y="513.554*mm" Z="1640.321*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="42" X="-96.919*mm" Y="518.469*mm" Z="1745.269*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="43" X="-96.000*mm" Y="513.554*mm" Z="1827.643*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="44" X="-96.919*mm" Y="518.469*mm" Z="1933.208*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="45" X="-96.000*mm" Y="513.554*mm" Z="2013.801*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="46" X="-96.919*mm" Y="518.469*mm" Z="2119.978*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="47" X="-96.000*mm" Y="513.554*mm" Z="2198.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidth="102.400*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidth="102.400*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </rodEven>
+                </rods>
+            </layer>
+            <layer id="2" radius="742.396*mm" rmin="733.462*mm" rmax="753.072*mm" bigDelta="5.000*mm" phi0="1.570796*rad">
+                <rods repeat="46" smallDelta="2.500*mm" rPhiOverlap="0.500*mm" nRPhiSegments="2" zOverlap="0.750*mm" nModules="47">
+                    <rodOdd id="1">
+                        <modules>
+                            <module id="1" X="0.000*mm" Y="744.896*mm" Z="-2198.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="2" X="0.000*mm" Y="749.896*mm" Z="-2119.978*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="3" X="0.000*mm" Y="744.896*mm" Z="-2013.801*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="4" X="0.000*mm" Y="749.896*mm" Z="-1933.208*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="5" X="0.000*mm" Y="744.896*mm" Z="-1827.643*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="6" X="0.000*mm" Y="749.896*mm" Z="-1745.269*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="7" X="0.000*mm" Y="744.896*mm" Z="-1640.321*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="8" X="0.000*mm" Y="749.896*mm" Z="-1556.154*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="9" X="0.000*mm" Y="744.896*mm" Z="-1451.827*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="10" X="0.000*mm" Y="749.896*mm" Z="-1365.856*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="11" X="0.000*mm" Y="744.896*mm" Z="-1262.153*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="12" X="0.000*mm" Y="749.896*mm" Z="-1174.366*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="13" X="0.000*mm" Y="744.896*mm" Z="-1071.292*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="14" X="0.000*mm" Y="749.896*mm" Z="-981.679*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="15" X="0.000*mm" Y="744.896*mm" Z="-879.236*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="16" X="0.000*mm" Y="749.896*mm" Z="-787.785*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="17" X="0.000*mm" Y="744.896*mm" Z="-685.978*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="18" X="0.000*mm" Y="749.896*mm" Z="-592.678*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="19" X="0.000*mm" Y="744.896*mm" Z="-491.511*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="20" X="0.000*mm" Y="749.896*mm" Z="-396.350*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="21" X="0.000*mm" Y="744.896*mm" Z="-295.827*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="22" X="0.000*mm" Y="749.896*mm" Z="-198.793*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="23" X="0.000*mm" Y="744.896*mm" Z="-98.919*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="24" X="0.000*mm" Y="749.896*mm" Z="0.000*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="25" X="0.000*mm" Y="744.896*mm" Z="98.919*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="26" X="0.000*mm" Y="749.896*mm" Z="198.793*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="27" X="0.000*mm" Y="744.896*mm" Z="295.827*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="28" X="0.000*mm" Y="749.896*mm" Z="396.350*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="29" X="0.000*mm" Y="744.896*mm" Z="491.511*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="30" X="0.000*mm" Y="749.896*mm" Z="592.678*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="31" X="0.000*mm" Y="744.896*mm" Z="685.978*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="32" X="0.000*mm" Y="749.896*mm" Z="787.785*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="33" X="0.000*mm" Y="744.896*mm" Z="879.236*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="34" X="0.000*mm" Y="749.896*mm" Z="981.679*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="35" X="0.000*mm" Y="744.896*mm" Z="1071.292*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="36" X="0.000*mm" Y="749.896*mm" Z="1174.366*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="37" X="0.000*mm" Y="744.896*mm" Z="1262.153*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="38" X="0.000*mm" Y="749.896*mm" Z="1365.856*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="39" X="0.000*mm" Y="744.896*mm" Z="1451.827*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="40" X="0.000*mm" Y="749.896*mm" Z="1556.154*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="41" X="0.000*mm" Y="744.896*mm" Z="1640.321*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="42" X="0.000*mm" Y="749.896*mm" Z="1745.269*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="43" X="0.000*mm" Y="744.896*mm" Z="1827.643*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="44" X="0.000*mm" Y="749.896*mm" Z="1933.208*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="45" X="0.000*mm" Y="744.896*mm" Z="2013.801*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="46" X="0.000*mm" Y="749.896*mm" Z="2119.978*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="47" X="0.000*mm" Y="744.896*mm" Z="2198.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidth="102.400*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidth="102.400*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </rodOdd>
+                    <rodEven id="2">
+                        <modules>
+                            <module id="1" X="-100.068*mm" Y="728.051*mm" Z="-2198.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="2" X="-100.749*mm" Y="733.005*mm" Z="-2119.978*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="3" X="-100.068*mm" Y="728.051*mm" Z="-2013.801*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="4" X="-100.749*mm" Y="733.005*mm" Z="-1933.208*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="5" X="-100.068*mm" Y="728.051*mm" Z="-1827.643*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="6" X="-100.749*mm" Y="733.005*mm" Z="-1745.269*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="7" X="-100.068*mm" Y="728.051*mm" Z="-1640.321*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="8" X="-100.749*mm" Y="733.005*mm" Z="-1556.154*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="9" X="-100.068*mm" Y="728.051*mm" Z="-1451.827*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="10" X="-100.749*mm" Y="733.005*mm" Z="-1365.856*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="11" X="-100.068*mm" Y="728.051*mm" Z="-1262.153*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="12" X="-100.749*mm" Y="733.005*mm" Z="-1174.366*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="13" X="-100.068*mm" Y="728.051*mm" Z="-1071.292*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="14" X="-100.749*mm" Y="733.005*mm" Z="-981.679*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="15" X="-100.068*mm" Y="728.051*mm" Z="-879.236*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="16" X="-100.749*mm" Y="733.005*mm" Z="-787.785*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="17" X="-100.068*mm" Y="728.051*mm" Z="-685.978*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="18" X="-100.749*mm" Y="733.005*mm" Z="-592.678*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="19" X="-100.068*mm" Y="728.051*mm" Z="-491.511*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="20" X="-100.749*mm" Y="733.005*mm" Z="-396.350*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="21" X="-100.068*mm" Y="728.051*mm" Z="-295.827*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="22" X="-100.749*mm" Y="733.005*mm" Z="-198.793*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="23" X="-100.068*mm" Y="728.051*mm" Z="-98.919*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="24" X="-100.749*mm" Y="733.005*mm" Z="0.000*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="25" X="-100.068*mm" Y="728.051*mm" Z="98.919*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="26" X="-100.749*mm" Y="733.005*mm" Z="198.793*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="27" X="-100.068*mm" Y="728.051*mm" Z="295.827*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="28" X="-100.749*mm" Y="733.005*mm" Z="396.350*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="29" X="-100.068*mm" Y="728.051*mm" Z="491.511*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="30" X="-100.749*mm" Y="733.005*mm" Z="592.678*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="31" X="-100.068*mm" Y="728.051*mm" Z="685.978*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="32" X="-100.749*mm" Y="733.005*mm" Z="787.785*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="33" X="-100.068*mm" Y="728.051*mm" Z="879.236*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="34" X="-100.749*mm" Y="733.005*mm" Z="981.679*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="35" X="-100.068*mm" Y="728.051*mm" Z="1071.292*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="36" X="-100.749*mm" Y="733.005*mm" Z="1174.366*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="37" X="-100.068*mm" Y="728.051*mm" Z="1262.153*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="38" X="-100.749*mm" Y="733.005*mm" Z="1365.856*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="39" X="-100.068*mm" Y="728.051*mm" Z="1451.827*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="40" X="-100.749*mm" Y="733.005*mm" Z="1556.154*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="41" X="-100.068*mm" Y="728.051*mm" Z="1640.321*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="42" X="-100.749*mm" Y="733.005*mm" Z="1745.269*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="43" X="-100.068*mm" Y="728.051*mm" Z="1827.643*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="44" X="-100.749*mm" Y="733.005*mm" Z="1933.208*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="45" X="-100.068*mm" Y="728.051*mm" Z="2013.801*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="46" X="-100.749*mm" Y="733.005*mm" Z="2119.978*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="47" X="-100.068*mm" Y="728.051*mm" Z="2198.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidth="102.400*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidth="102.400*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </rodEven>
+                </rods>
+            </layer>
+            <layer id="3" radius="937.244*mm" rmin="927.950*mm" rmax="947.921*mm" bigDelta="5.000*mm" phi0="1.570796*rad">
+                <rods repeat="58" smallDelta="2.500*mm" rPhiOverlap="0.500*mm" nRPhiSegments="2" zOverlap="0.750*mm" nModules="47">
+                    <rodOdd id="1">
+                        <modules>
+                            <module id="1" X="0.000*mm" Y="939.744*mm" Z="-2198.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="2" X="0.000*mm" Y="944.744*mm" Z="-2119.976*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="3" X="0.000*mm" Y="939.744*mm" Z="-2013.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="4" X="0.000*mm" Y="944.744*mm" Z="-1933.206*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="5" X="0.000*mm" Y="939.744*mm" Z="-1827.642*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="6" X="0.000*mm" Y="944.744*mm" Z="-1745.266*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="7" X="0.000*mm" Y="939.744*mm" Z="-1640.319*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="8" X="0.000*mm" Y="944.744*mm" Z="-1556.151*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="9" X="0.000*mm" Y="939.744*mm" Z="-1451.824*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="10" X="0.000*mm" Y="944.744*mm" Z="-1365.852*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="11" X="0.000*mm" Y="939.744*mm" Z="-1262.150*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="12" X="0.000*mm" Y="944.744*mm" Z="-1174.363*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="13" X="0.000*mm" Y="939.744*mm" Z="-1071.288*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="14" X="0.000*mm" Y="944.744*mm" Z="-981.675*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="15" X="0.000*mm" Y="939.744*mm" Z="-879.233*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="16" X="0.000*mm" Y="944.744*mm" Z="-787.782*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="17" X="0.000*mm" Y="939.744*mm" Z="-685.976*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="18" X="0.000*mm" Y="944.744*mm" Z="-592.675*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="19" X="0.000*mm" Y="939.744*mm" Z="-491.509*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="20" X="0.000*mm" Y="944.744*mm" Z="-396.348*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="21" X="0.000*mm" Y="939.744*mm" Z="-295.826*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="22" X="0.000*mm" Y="944.744*mm" Z="-198.792*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="23" X="0.000*mm" Y="939.744*mm" Z="-98.918*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="24" X="0.000*mm" Y="944.744*mm" Z="0.000*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="25" X="0.000*mm" Y="939.744*mm" Z="98.918*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="26" X="0.000*mm" Y="944.744*mm" Z="198.792*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="27" X="0.000*mm" Y="939.744*mm" Z="295.826*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="28" X="0.000*mm" Y="944.744*mm" Z="396.348*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="29" X="0.000*mm" Y="939.744*mm" Z="491.509*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="30" X="0.000*mm" Y="944.744*mm" Z="592.675*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="31" X="0.000*mm" Y="939.744*mm" Z="685.976*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="32" X="0.000*mm" Y="944.744*mm" Z="787.782*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="33" X="0.000*mm" Y="939.744*mm" Z="879.233*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="34" X="0.000*mm" Y="944.744*mm" Z="981.675*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="35" X="0.000*mm" Y="939.744*mm" Z="1071.288*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="36" X="0.000*mm" Y="944.744*mm" Z="1174.363*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="37" X="0.000*mm" Y="939.744*mm" Z="1262.150*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="38" X="0.000*mm" Y="944.744*mm" Z="1365.852*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="39" X="0.000*mm" Y="939.744*mm" Z="1451.824*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="40" X="0.000*mm" Y="944.744*mm" Z="1556.151*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="41" X="0.000*mm" Y="939.744*mm" Z="1640.319*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="42" X="0.000*mm" Y="944.744*mm" Z="1745.266*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="43" X="0.000*mm" Y="939.744*mm" Z="1827.642*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="44" X="0.000*mm" Y="944.744*mm" Z="1933.206*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="45" X="0.000*mm" Y="939.744*mm" Z="2013.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="46" X="0.000*mm" Y="944.744*mm" Z="2119.976*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="47" X="0.000*mm" Y="939.744*mm" Z="2198.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidth="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidth="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="14434.0*um"/>
+                    </rodOdd>
+                    <rodEven id="2">
+                        <modules>
+                            <module id="1" X="-100.523*mm" Y="924.294*mm" Z="-2198.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="2" X="-101.064*mm" Y="929.264*mm" Z="-2119.976*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="3" X="-100.523*mm" Y="924.294*mm" Z="-2013.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="4" X="-101.064*mm" Y="929.264*mm" Z="-1933.206*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="5" X="-100.523*mm" Y="924.294*mm" Z="-1827.642*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="6" X="-101.064*mm" Y="929.264*mm" Z="-1745.266*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="7" X="-100.523*mm" Y="924.294*mm" Z="-1640.319*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="8" X="-101.064*mm" Y="929.264*mm" Z="-1556.151*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="9" X="-100.523*mm" Y="924.294*mm" Z="-1451.824*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="10" X="-101.064*mm" Y="929.264*mm" Z="-1365.852*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="11" X="-100.523*mm" Y="924.294*mm" Z="-1262.150*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="12" X="-101.064*mm" Y="929.264*mm" Z="-1174.363*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="13" X="-100.523*mm" Y="924.294*mm" Z="-1071.288*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="14" X="-101.064*mm" Y="929.264*mm" Z="-981.675*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="15" X="-100.523*mm" Y="924.294*mm" Z="-879.233*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="16" X="-101.064*mm" Y="929.264*mm" Z="-787.782*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="17" X="-100.523*mm" Y="924.294*mm" Z="-685.976*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="18" X="-101.064*mm" Y="929.264*mm" Z="-592.675*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="19" X="-100.523*mm" Y="924.294*mm" Z="-491.509*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="20" X="-101.064*mm" Y="929.264*mm" Z="-396.348*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="21" X="-100.523*mm" Y="924.294*mm" Z="-295.826*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="22" X="-101.064*mm" Y="929.264*mm" Z="-198.792*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="23" X="-100.523*mm" Y="924.294*mm" Z="-98.918*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="24" X="-101.064*mm" Y="929.264*mm" Z="0.000*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="25" X="-100.523*mm" Y="924.294*mm" Z="98.918*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="26" X="-101.064*mm" Y="929.264*mm" Z="198.792*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="27" X="-100.523*mm" Y="924.294*mm" Z="295.826*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="28" X="-101.064*mm" Y="929.264*mm" Z="396.348*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="29" X="-100.523*mm" Y="924.294*mm" Z="491.509*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="30" X="-101.064*mm" Y="929.264*mm" Z="592.675*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="31" X="-100.523*mm" Y="924.294*mm" Z="685.976*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="32" X="-101.064*mm" Y="929.264*mm" Z="787.782*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="33" X="-100.523*mm" Y="924.294*mm" Z="879.233*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="34" X="-101.064*mm" Y="929.264*mm" Z="981.675*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="35" X="-100.523*mm" Y="924.294*mm" Z="1071.288*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="36" X="-101.064*mm" Y="929.264*mm" Z="1174.363*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="37" X="-100.523*mm" Y="924.294*mm" Z="1262.150*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="38" X="-101.064*mm" Y="929.264*mm" Z="1365.852*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="39" X="-100.523*mm" Y="924.294*mm" Z="1451.824*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="40" X="-101.064*mm" Y="929.264*mm" Z="1556.151*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="41" X="-100.523*mm" Y="924.294*mm" Z="1640.319*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="42" X="-101.064*mm" Y="929.264*mm" Z="1745.266*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="43" X="-100.523*mm" Y="924.294*mm" Z="1827.642*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="44" X="-101.064*mm" Y="929.264*mm" Z="1933.206*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="45" X="-100.523*mm" Y="924.294*mm" Z="2013.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="46" X="-101.064*mm" Y="929.264*mm" Z="2119.976*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="47" X="-100.523*mm" Y="924.294*mm" Z="2198.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidth="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidth="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="14434.0*um"/>
+                    </rodEven>
+                </rods>
+            </layer>
+            <layer id="4" radius="1132.012*mm" rmin="1122.718*mm" rmax="1142.453*mm" bigDelta="5.000*mm" phi0="1.570796*rad">
+                <rods repeat="70" smallDelta="2.500*mm" rPhiOverlap="0.500*mm" nRPhiSegments="2" zOverlap="0.750*mm" nModules="47">
+                    <rodOdd id="1">
+                        <modules>
+                            <module id="1" X="0.000*mm" Y="1134.512*mm" Z="-2198.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="2" X="0.000*mm" Y="1139.512*mm" Z="-2119.976*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="3" X="0.000*mm" Y="1134.512*mm" Z="-2013.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="4" X="0.000*mm" Y="1139.512*mm" Z="-1933.206*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="5" X="0.000*mm" Y="1134.512*mm" Z="-1827.642*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="6" X="0.000*mm" Y="1139.512*mm" Z="-1745.266*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="7" X="0.000*mm" Y="1134.512*mm" Z="-1640.319*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="8" X="0.000*mm" Y="1139.512*mm" Z="-1556.151*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="9" X="0.000*mm" Y="1134.512*mm" Z="-1451.824*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="10" X="0.000*mm" Y="1139.512*mm" Z="-1365.852*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="11" X="0.000*mm" Y="1134.512*mm" Z="-1262.150*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="12" X="0.000*mm" Y="1139.512*mm" Z="-1174.363*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="13" X="0.000*mm" Y="1134.512*mm" Z="-1071.288*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="14" X="0.000*mm" Y="1139.512*mm" Z="-981.675*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="15" X="0.000*mm" Y="1134.512*mm" Z="-879.233*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="16" X="0.000*mm" Y="1139.512*mm" Z="-787.782*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="17" X="0.000*mm" Y="1134.512*mm" Z="-685.976*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="18" X="0.000*mm" Y="1139.512*mm" Z="-592.675*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="19" X="0.000*mm" Y="1134.512*mm" Z="-491.509*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="20" X="0.000*mm" Y="1139.512*mm" Z="-396.348*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="21" X="0.000*mm" Y="1134.512*mm" Z="-295.826*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="22" X="0.000*mm" Y="1139.512*mm" Z="-198.792*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="23" X="0.000*mm" Y="1134.512*mm" Z="-98.918*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="24" X="0.000*mm" Y="1139.512*mm" Z="0.000*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="25" X="0.000*mm" Y="1134.512*mm" Z="98.918*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="26" X="0.000*mm" Y="1139.512*mm" Z="198.792*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="27" X="0.000*mm" Y="1134.512*mm" Z="295.826*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="28" X="0.000*mm" Y="1139.512*mm" Z="396.348*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="29" X="0.000*mm" Y="1134.512*mm" Z="491.509*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="30" X="0.000*mm" Y="1139.512*mm" Z="592.675*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="31" X="0.000*mm" Y="1134.512*mm" Z="685.976*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="32" X="0.000*mm" Y="1139.512*mm" Z="787.782*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="33" X="0.000*mm" Y="1134.512*mm" Z="879.233*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="34" X="0.000*mm" Y="1139.512*mm" Z="981.675*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="35" X="0.000*mm" Y="1134.512*mm" Z="1071.288*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="36" X="0.000*mm" Y="1139.512*mm" Z="1174.363*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="37" X="0.000*mm" Y="1134.512*mm" Z="1262.150*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="38" X="0.000*mm" Y="1139.512*mm" Z="1365.852*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="39" X="0.000*mm" Y="1134.512*mm" Z="1451.824*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="40" X="0.000*mm" Y="1139.512*mm" Z="1556.151*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="41" X="0.000*mm" Y="1134.512*mm" Z="1640.319*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="42" X="0.000*mm" Y="1139.512*mm" Z="1745.266*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="43" X="0.000*mm" Y="1134.512*mm" Z="1827.642*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="44" X="0.000*mm" Y="1139.512*mm" Z="1933.206*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="45" X="0.000*mm" Y="1134.512*mm" Z="2013.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="46" X="0.000*mm" Y="1139.512*mm" Z="2119.976*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="47" X="0.000*mm" Y="1134.512*mm" Z="2198.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidth="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidth="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="14434.0*um"/>
+                    </rodOdd>
+                    <rodEven id="2">
+                        <modules>
+                            <module id="1" X="-100.800*mm" Y="1119.985*mm" Z="-2198.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="2" X="-101.249*mm" Y="1124.965*mm" Z="-2119.976*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="3" X="-100.800*mm" Y="1119.985*mm" Z="-2013.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="4" X="-101.249*mm" Y="1124.965*mm" Z="-1933.206*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="5" X="-100.800*mm" Y="1119.985*mm" Z="-1827.642*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="6" X="-101.249*mm" Y="1124.965*mm" Z="-1745.266*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="7" X="-100.800*mm" Y="1119.985*mm" Z="-1640.319*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="8" X="-101.249*mm" Y="1124.965*mm" Z="-1556.151*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="9" X="-100.800*mm" Y="1119.985*mm" Z="-1451.824*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="10" X="-101.249*mm" Y="1124.965*mm" Z="-1365.852*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="11" X="-100.800*mm" Y="1119.985*mm" Z="-1262.150*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="12" X="-101.249*mm" Y="1124.965*mm" Z="-1174.363*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="13" X="-100.800*mm" Y="1119.985*mm" Z="-1071.288*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="14" X="-101.249*mm" Y="1124.965*mm" Z="-981.675*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="15" X="-100.800*mm" Y="1119.985*mm" Z="-879.233*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="16" X="-101.249*mm" Y="1124.965*mm" Z="-787.782*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="17" X="-100.800*mm" Y="1119.985*mm" Z="-685.976*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="18" X="-101.249*mm" Y="1124.965*mm" Z="-592.675*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="19" X="-100.800*mm" Y="1119.985*mm" Z="-491.509*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="20" X="-101.249*mm" Y="1124.965*mm" Z="-396.348*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="21" X="-100.800*mm" Y="1119.985*mm" Z="-295.826*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="22" X="-101.249*mm" Y="1124.965*mm" Z="-198.792*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="23" X="-100.800*mm" Y="1119.985*mm" Z="-98.918*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="24" X="-101.249*mm" Y="1124.965*mm" Z="0.000*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="25" X="-100.800*mm" Y="1119.985*mm" Z="98.918*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="26" X="-101.249*mm" Y="1124.965*mm" Z="198.792*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="27" X="-100.800*mm" Y="1119.985*mm" Z="295.826*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="28" X="-101.249*mm" Y="1124.965*mm" Z="396.348*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="29" X="-100.800*mm" Y="1119.985*mm" Z="491.509*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="30" X="-101.249*mm" Y="1124.965*mm" Z="592.675*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="31" X="-100.800*mm" Y="1119.985*mm" Z="685.976*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="32" X="-101.249*mm" Y="1124.965*mm" Z="787.782*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="33" X="-100.800*mm" Y="1119.985*mm" Z="879.233*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="34" X="-101.249*mm" Y="1124.965*mm" Z="981.675*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="35" X="-100.800*mm" Y="1119.985*mm" Z="1071.288*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="36" X="-101.249*mm" Y="1124.965*mm" Z="1174.363*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="37" X="-100.800*mm" Y="1119.985*mm" Z="1262.150*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="38" X="-101.249*mm" Y="1124.965*mm" Z="1365.852*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="39" X="-100.800*mm" Y="1119.985*mm" Z="1451.824*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="40" X="-101.249*mm" Y="1124.965*mm" Z="1556.151*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="41" X="-100.800*mm" Y="1119.985*mm" Z="1640.319*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="42" X="-101.249*mm" Y="1124.965*mm" Z="1745.266*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="43" X="-100.800*mm" Y="1119.985*mm" Z="1827.642*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="44" X="-101.249*mm" Y="1124.965*mm" Z="1933.206*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="45" X="-100.800*mm" Y="1119.985*mm" Z="2013.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="46" X="-101.249*mm" Y="1124.965*mm" Z="2119.976*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="47" X="-100.800*mm" Y="1119.985*mm" Z="2198.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidth="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidth="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="14434.0*um"/>
+                    </rodEven>
+                </rods>
+            </layer>
+            <layer id="5" radius="1326.735*mm" rmin="1317.441*mm" rmax="1337.009*mm" bigDelta="5.000*mm" phi0="1.570796*rad">
+                <rods repeat="82" smallDelta="2.500*mm" rPhiOverlap="0.500*mm" nRPhiSegments="2" zOverlap="0.750*mm" nModules="47">
+                    <rodOdd id="1">
+                        <modules>
+                            <module id="1" X="0.000*mm" Y="1329.235*mm" Z="-2198.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="2" X="0.000*mm" Y="1334.235*mm" Z="-2119.976*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="3" X="0.000*mm" Y="1329.235*mm" Z="-2013.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="4" X="0.000*mm" Y="1334.235*mm" Z="-1933.206*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="5" X="0.000*mm" Y="1329.235*mm" Z="-1827.642*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="6" X="0.000*mm" Y="1334.235*mm" Z="-1745.266*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="7" X="0.000*mm" Y="1329.235*mm" Z="-1640.319*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="8" X="0.000*mm" Y="1334.235*mm" Z="-1556.151*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="9" X="0.000*mm" Y="1329.235*mm" Z="-1451.824*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="10" X="0.000*mm" Y="1334.235*mm" Z="-1365.852*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="11" X="0.000*mm" Y="1329.235*mm" Z="-1262.150*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="12" X="0.000*mm" Y="1334.235*mm" Z="-1174.363*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="13" X="0.000*mm" Y="1329.235*mm" Z="-1071.288*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="14" X="0.000*mm" Y="1334.235*mm" Z="-981.675*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="15" X="0.000*mm" Y="1329.235*mm" Z="-879.233*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="16" X="0.000*mm" Y="1334.235*mm" Z="-787.782*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="17" X="0.000*mm" Y="1329.235*mm" Z="-685.976*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="18" X="0.000*mm" Y="1334.235*mm" Z="-592.675*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="19" X="0.000*mm" Y="1329.235*mm" Z="-491.509*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="20" X="0.000*mm" Y="1334.235*mm" Z="-396.348*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="21" X="0.000*mm" Y="1329.235*mm" Z="-295.826*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="22" X="0.000*mm" Y="1334.235*mm" Z="-198.792*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="23" X="0.000*mm" Y="1329.235*mm" Z="-98.918*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="24" X="0.000*mm" Y="1334.235*mm" Z="0.000*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="25" X="0.000*mm" Y="1329.235*mm" Z="98.918*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="26" X="0.000*mm" Y="1334.235*mm" Z="198.792*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="27" X="0.000*mm" Y="1329.235*mm" Z="295.826*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="28" X="0.000*mm" Y="1334.235*mm" Z="396.348*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="29" X="0.000*mm" Y="1329.235*mm" Z="491.509*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="30" X="0.000*mm" Y="1334.235*mm" Z="592.675*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="31" X="0.000*mm" Y="1329.235*mm" Z="685.976*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="32" X="0.000*mm" Y="1334.235*mm" Z="787.782*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="33" X="0.000*mm" Y="1329.235*mm" Z="879.233*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="34" X="0.000*mm" Y="1334.235*mm" Z="981.675*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="35" X="0.000*mm" Y="1329.235*mm" Z="1071.288*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="36" X="0.000*mm" Y="1334.235*mm" Z="1174.363*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="37" X="0.000*mm" Y="1329.235*mm" Z="1262.150*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="38" X="0.000*mm" Y="1334.235*mm" Z="1365.852*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="39" X="0.000*mm" Y="1329.235*mm" Z="1451.824*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="40" X="0.000*mm" Y="1334.235*mm" Z="1556.151*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="41" X="0.000*mm" Y="1329.235*mm" Z="1640.319*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="42" X="0.000*mm" Y="1334.235*mm" Z="1745.266*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="43" X="0.000*mm" Y="1329.235*mm" Z="1827.642*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="44" X="0.000*mm" Y="1334.235*mm" Z="1933.206*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="45" X="0.000*mm" Y="1329.235*mm" Z="2013.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="46" X="0.000*mm" Y="1334.235*mm" Z="2119.976*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="47" X="0.000*mm" Y="1329.235*mm" Z="2198.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidth="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidth="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="14434.0*um"/>
+                    </rodOdd>
+                    <rodEven id="2">
+                        <modules>
+                            <module id="1" X="-100.986*mm" Y="1315.364*mm" Z="-2198.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="2" X="-101.369*mm" Y="1320.349*mm" Z="-2119.976*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="3" X="-100.986*mm" Y="1315.364*mm" Z="-2013.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="4" X="-101.369*mm" Y="1320.349*mm" Z="-1933.206*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="5" X="-100.986*mm" Y="1315.364*mm" Z="-1827.642*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="6" X="-101.369*mm" Y="1320.349*mm" Z="-1745.266*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="7" X="-100.986*mm" Y="1315.364*mm" Z="-1640.319*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="8" X="-101.369*mm" Y="1320.349*mm" Z="-1556.151*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="9" X="-100.986*mm" Y="1315.364*mm" Z="-1451.824*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="10" X="-101.369*mm" Y="1320.349*mm" Z="-1365.852*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="11" X="-100.986*mm" Y="1315.364*mm" Z="-1262.150*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="12" X="-101.369*mm" Y="1320.349*mm" Z="-1174.363*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="13" X="-100.986*mm" Y="1315.364*mm" Z="-1071.288*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="14" X="-101.369*mm" Y="1320.349*mm" Z="-981.675*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="15" X="-100.986*mm" Y="1315.364*mm" Z="-879.233*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="16" X="-101.369*mm" Y="1320.349*mm" Z="-787.782*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="17" X="-100.986*mm" Y="1315.364*mm" Z="-685.976*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="18" X="-101.369*mm" Y="1320.349*mm" Z="-592.675*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="19" X="-100.986*mm" Y="1315.364*mm" Z="-491.509*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="20" X="-101.369*mm" Y="1320.349*mm" Z="-396.348*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="21" X="-100.986*mm" Y="1315.364*mm" Z="-295.826*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="22" X="-101.369*mm" Y="1320.349*mm" Z="-198.792*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="23" X="-100.986*mm" Y="1315.364*mm" Z="-98.918*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="24" X="-101.369*mm" Y="1320.349*mm" Z="0.000*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="25" X="-100.986*mm" Y="1315.364*mm" Z="98.918*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="26" X="-101.369*mm" Y="1320.349*mm" Z="198.792*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="27" X="-100.986*mm" Y="1315.364*mm" Z="295.826*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="28" X="-101.369*mm" Y="1320.349*mm" Z="396.348*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="29" X="-100.986*mm" Y="1315.364*mm" Z="491.509*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="30" X="-101.369*mm" Y="1320.349*mm" Z="592.675*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="31" X="-100.986*mm" Y="1315.364*mm" Z="685.976*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="32" X="-101.369*mm" Y="1320.349*mm" Z="787.782*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="33" X="-100.986*mm" Y="1315.364*mm" Z="879.233*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="34" X="-101.369*mm" Y="1320.349*mm" Z="981.675*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="35" X="-100.986*mm" Y="1315.364*mm" Z="1071.288*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="36" X="-101.369*mm" Y="1320.349*mm" Z="1174.363*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="37" X="-100.986*mm" Y="1315.364*mm" Z="1262.150*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="38" X="-101.369*mm" Y="1320.349*mm" Z="1365.852*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="39" X="-100.986*mm" Y="1315.364*mm" Z="1451.824*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="40" X="-101.369*mm" Y="1320.349*mm" Z="1556.151*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="41" X="-100.986*mm" Y="1315.364*mm" Z="1640.319*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="42" X="-101.369*mm" Y="1320.349*mm" Z="1745.266*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="43" X="-100.986*mm" Y="1315.364*mm" Z="1827.642*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="44" X="-101.369*mm" Y="1320.349*mm" Z="1933.206*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="45" X="-100.986*mm" Y="1315.364*mm" Z="2013.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="46" X="-101.369*mm" Y="1320.349*mm" Z="2119.976*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="47" X="-100.986*mm" Y="1315.364*mm" Z="2198.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidth="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidth="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="14434.0*um"/>
+                    </rodEven>
+                </rods>
+            </layer>
+            <layer id="6" radius="1516.536*mm" rmin="1507.243*mm" rmax="1526.688*mm" bigDelta="5.000*mm" phi0="1.570796*rad">
+                <rods repeat="94" smallDelta="2.500*mm" rPhiOverlap="0.500*mm" nRPhiSegments="2" zOverlap="0.750*mm" nModules="47">
+                    <rodOdd id="1">
+                        <modules>
+                            <module id="1" X="0.000*mm" Y="1519.036*mm" Z="-2198.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="2" X="0.000*mm" Y="1524.036*mm" Z="-2119.976*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="3" X="0.000*mm" Y="1519.036*mm" Z="-2013.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="4" X="0.000*mm" Y="1524.036*mm" Z="-1933.206*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="5" X="0.000*mm" Y="1519.036*mm" Z="-1827.642*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="6" X="0.000*mm" Y="1524.036*mm" Z="-1745.266*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="7" X="0.000*mm" Y="1519.036*mm" Z="-1640.319*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="8" X="0.000*mm" Y="1524.036*mm" Z="-1556.151*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="9" X="0.000*mm" Y="1519.036*mm" Z="-1451.824*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="10" X="0.000*mm" Y="1524.036*mm" Z="-1365.852*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="11" X="0.000*mm" Y="1519.036*mm" Z="-1262.150*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="12" X="0.000*mm" Y="1524.036*mm" Z="-1174.363*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="13" X="0.000*mm" Y="1519.036*mm" Z="-1071.288*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="14" X="0.000*mm" Y="1524.036*mm" Z="-981.675*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="15" X="0.000*mm" Y="1519.036*mm" Z="-879.233*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="16" X="0.000*mm" Y="1524.036*mm" Z="-787.782*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="17" X="0.000*mm" Y="1519.036*mm" Z="-685.976*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="18" X="0.000*mm" Y="1524.036*mm" Z="-592.675*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="19" X="0.000*mm" Y="1519.036*mm" Z="-491.509*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="20" X="0.000*mm" Y="1524.036*mm" Z="-396.348*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="21" X="0.000*mm" Y="1519.036*mm" Z="-295.826*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="22" X="0.000*mm" Y="1524.036*mm" Z="-198.792*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="23" X="0.000*mm" Y="1519.036*mm" Z="-98.918*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="24" X="0.000*mm" Y="1524.036*mm" Z="0.000*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="25" X="0.000*mm" Y="1519.036*mm" Z="98.918*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="26" X="0.000*mm" Y="1524.036*mm" Z="198.792*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="27" X="0.000*mm" Y="1519.036*mm" Z="295.826*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="28" X="0.000*mm" Y="1524.036*mm" Z="396.348*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="29" X="0.000*mm" Y="1519.036*mm" Z="491.509*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="30" X="0.000*mm" Y="1524.036*mm" Z="592.675*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="31" X="0.000*mm" Y="1519.036*mm" Z="685.976*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="32" X="0.000*mm" Y="1524.036*mm" Z="787.782*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="33" X="0.000*mm" Y="1519.036*mm" Z="879.233*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="34" X="0.000*mm" Y="1524.036*mm" Z="981.675*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="35" X="0.000*mm" Y="1519.036*mm" Z="1071.288*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="36" X="0.000*mm" Y="1524.036*mm" Z="1174.363*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="37" X="0.000*mm" Y="1519.036*mm" Z="1262.150*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="38" X="0.000*mm" Y="1524.036*mm" Z="1365.852*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="39" X="0.000*mm" Y="1519.036*mm" Z="1451.824*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="40" X="0.000*mm" Y="1524.036*mm" Z="1556.151*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="41" X="0.000*mm" Y="1519.036*mm" Z="1640.319*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="42" X="0.000*mm" Y="1524.036*mm" Z="1745.266*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="43" X="0.000*mm" Y="1519.036*mm" Z="1827.642*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="44" X="0.000*mm" Y="1524.036*mm" Z="1933.206*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="45" X="0.000*mm" Y="1519.036*mm" Z="2013.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="46" X="0.000*mm" Y="1524.036*mm" Z="2119.976*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="47" X="0.000*mm" Y="1519.036*mm" Z="2198.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidth="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidth="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="14434.0*um"/>
+                    </rodOdd>
+                    <rodEven id="2">
+                        <modules>
+                            <module id="1" X="-100.792*mm" Y="1505.666*mm" Z="-2198.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="2" X="-101.126*mm" Y="1510.655*mm" Z="-2119.976*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="3" X="-100.792*mm" Y="1505.666*mm" Z="-2013.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="4" X="-101.126*mm" Y="1510.655*mm" Z="-1933.206*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="5" X="-100.792*mm" Y="1505.666*mm" Z="-1827.642*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="6" X="-101.126*mm" Y="1510.655*mm" Z="-1745.266*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="7" X="-100.792*mm" Y="1505.666*mm" Z="-1640.319*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="8" X="-101.126*mm" Y="1510.655*mm" Z="-1556.151*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="9" X="-100.792*mm" Y="1505.666*mm" Z="-1451.824*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="10" X="-101.126*mm" Y="1510.655*mm" Z="-1365.852*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="11" X="-100.792*mm" Y="1505.666*mm" Z="-1262.150*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="12" X="-101.126*mm" Y="1510.655*mm" Z="-1174.363*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="13" X="-100.792*mm" Y="1505.666*mm" Z="-1071.288*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="14" X="-101.126*mm" Y="1510.655*mm" Z="-981.675*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="15" X="-100.792*mm" Y="1505.666*mm" Z="-879.233*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="16" X="-101.126*mm" Y="1510.655*mm" Z="-787.782*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="17" X="-100.792*mm" Y="1505.666*mm" Z="-685.976*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="18" X="-101.126*mm" Y="1510.655*mm" Z="-592.675*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="19" X="-100.792*mm" Y="1505.666*mm" Z="-491.509*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="20" X="-101.126*mm" Y="1510.655*mm" Z="-396.348*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="21" X="-100.792*mm" Y="1505.666*mm" Z="-295.826*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="22" X="-101.126*mm" Y="1510.655*mm" Z="-198.792*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="23" X="-100.792*mm" Y="1505.666*mm" Z="-98.918*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="24" X="-101.126*mm" Y="1510.655*mm" Z="0.000*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="25" X="-100.792*mm" Y="1505.666*mm" Z="98.918*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="26" X="-101.126*mm" Y="1510.655*mm" Z="198.792*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="27" X="-100.792*mm" Y="1505.666*mm" Z="295.826*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="28" X="-101.126*mm" Y="1510.655*mm" Z="396.348*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="29" X="-100.792*mm" Y="1505.666*mm" Z="491.509*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="30" X="-101.126*mm" Y="1510.655*mm" Z="592.675*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="31" X="-100.792*mm" Y="1505.666*mm" Z="685.976*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="32" X="-101.126*mm" Y="1510.655*mm" Z="787.782*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="33" X="-100.792*mm" Y="1505.666*mm" Z="879.233*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="34" X="-101.126*mm" Y="1510.655*mm" Z="981.675*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="35" X="-100.792*mm" Y="1505.666*mm" Z="1071.288*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="36" X="-101.126*mm" Y="1510.655*mm" Z="1174.363*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="37" X="-100.792*mm" Y="1505.666*mm" Z="1262.150*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="38" X="-101.126*mm" Y="1510.655*mm" Z="1365.852*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="39" X="-100.792*mm" Y="1505.666*mm" Z="1451.824*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="40" X="-101.126*mm" Y="1510.655*mm" Z="1556.151*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="41" X="-100.792*mm" Y="1505.666*mm" Z="1640.319*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="42" X="-101.126*mm" Y="1510.655*mm" Z="1745.266*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="43" X="-100.792*mm" Y="1505.666*mm" Z="1827.642*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="44" X="-101.126*mm" Y="1510.655*mm" Z="1933.206*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="45" X="-100.792*mm" Y="1505.666*mm" Z="2013.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="46" X="-101.126*mm" Y="1510.655*mm" Z="2119.976*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="47" X="-100.792*mm" Y="1505.666*mm" Z="2198.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidth="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidth="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="14434.0*um"/>
+                    </rodEven>
+                </rods>
+            </layer>
+        </layers>
+    </detector>
+    <detector name="OuterECAPpos" id="EndCapTrackerOuter_id" type="TkLayoutEcapTracker" readout="TrackerEndcapReadout">
+        <dimensions rmin="25.000*mm" rmax="1549.268*mm" zmin="2615.706*mm" zmax="5009.294*mm" reflect="false"/>
+        <sensitive type="SimpleTrackerSD"/>
+        <discs repeat="12">
+            <discZPls id="1" z="2625.000*mm" zmin="2615.706*mm" zmax="2634.294*mm" rmin="25.000*mm" rmax="1549.268*mm" bigDelta="5.000*mm">
+                <rings repeat="16" smallDelta="2.500*mm" rPhiOverlap="0.500*mm" nRPhiSegments="4" rOverlap="0.500*mm">
+                    <ring id="1" phi0="0.000000*rad" nModules="12">
+                        <modules>
+                            <moduleOdd id="1" X="62.666*mm" Y="0.000*mm" Z="2622.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="54.270*mm" Y="31.333*mm" Z="2617.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="75.332*mm" modWidthMin="13.935*mm" modWidthMax="55.924*mm" modThickness="2.150*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.330*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.043*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.129*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="0.903*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.645*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="75.332*mm" sensorWidthMin="13.935*mm" sensorWidthMax="55.924*mm" sensorThickness="0.100*mm" resRPhi="7.5*um" resZ="15.0*um"/>
+                    </ring>
+                    <ring id="2" phi0="0.000000*rad" nModules="20">
+                        <modules>
+                            <moduleOdd id="1" X="150.203*mm" Y="0.000*mm" Z="2632.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="142.851*mm" Y="46.415*mm" Z="2627.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="100.543*mm" modWidthMin="32.168*mm" modWidthMax="64.533*mm" modThickness="2.150*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.330*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.043*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.129*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="0.903*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.645*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="100.543*mm" sensorWidthMin="32.168*mm" sensorWidthMax="64.533*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="30.0*um"/>
+                    </ring>
+                    <ring id="3" phi0="0.000000*rad" nModules="32">
+                        <modules>
+                            <moduleOdd id="1" X="250.208*mm" Y="0.000*mm" Z="2622.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="245.400*mm" Y="48.813*mm" Z="2617.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.747*mm" modWidthMin="39.672*mm" modWidthMax="60.172*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.747*mm" sensorWidthMin="39.672*mm" sensorWidthMax="60.172*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="4" phi0="0.000000*rad" nModules="44">
+                        <modules>
+                            <moduleOdd id="1" X="351.448*mm" Y="0.000*mm" Z="2632.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="347.871*mm" Y="50.016*mm" Z="2627.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="100.131*mm" modWidthMin="43.613*mm" modWidthMax="58.103*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="100.131*mm" sensorWidthMin="43.613*mm" sensorWidthMax="58.103*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="5" phi0="0.000000*rad" nModules="52">
+                        <modules>
+                            <moduleOdd id="1" X="451.105*mm" Y="0.000*mm" Z="2622.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="447.816*mm" Y="54.375*mm" Z="2617.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="104.752*mm" modWidthMin="48.739*mm" modWidthMax="61.544*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="104.752*mm" sensorWidthMin="48.739*mm" sensorWidthMax="61.544*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="6" phi0="0.000000*rad" nModules="64">
+                        <modules>
+                            <moduleOdd id="1" X="553.187*mm" Y="0.000*mm" Z="2632.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="550.523*mm" Y="54.222*mm" Z="2627.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="99.406*mm" modWidthMin="49.970*mm" modWidthMax="59.836*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="99.406*mm" sensorWidthMin="49.970*mm" sensorWidthMax="59.836*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="7" phi0="0.000000*rad" nModules="44">
+                        <modules>
+                            <moduleOdd id="1" X="650.158*mm" Y="0.000*mm" Z="2622.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="643.540*mm" Y="92.527*mm" Z="2617.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="8" phi0="0.000000*rad" nModules="52">
+                        <modules>
+                            <moduleOdd id="1" X="752.759*mm" Y="0.000*mm" Z="2632.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="747.270*mm" Y="90.735*mm" Z="2627.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="9" phi0="0.000000*rad" nModules="56">
+                        <modules>
+                            <moduleOdd id="1" X="850.081*mm" Y="0.000*mm" Z="2622.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="844.736*mm" Y="95.179*mm" Z="2617.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="10" phi0="0.000000*rad" nModules="64">
+                        <modules>
+                            <moduleOdd id="1" X="952.882*mm" Y="0.000*mm" Z="2632.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="948.294*mm" Y="93.399*mm" Z="2627.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="2887.0*um"/>
+                    </ring>
+                    <ring id="11" phi0="0.000000*rad" nModules="68">
+                        <modules>
+                            <moduleOdd id="1" X="1049.064*mm" Y="0.000*mm" Z="2622.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="1044.589*mm" Y="96.795*mm" Z="2617.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="2887.0*um"/>
+                    </ring>
+                    <ring id="12" phi0="0.000000*rad" nModules="76">
+                        <modules>
+                            <moduleOdd id="1" X="1152.064*mm" Y="0.000*mm" Z="2632.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="1148.129*mm" Y="95.137*mm" Z="2627.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="2887.0*um"/>
+                    </ring>
+                    <ring id="13" phi0="0.000000*rad" nModules="84">
+                        <modules>
+                            <moduleOdd id="1" X="1247.111*mm" Y="0.000*mm" Z="2622.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="1243.623*mm" Y="93.197*mm" Z="2617.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="2887.0*um"/>
+                    </ring>
+                    <ring id="14" phi0="0.000000*rad" nModules="88">
+                        <modules>
+                            <moduleOdd id="1" X="1350.309*mm" Y="0.000*mm" Z="2632.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="1346.869*mm" Y="96.330*mm" Z="2627.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="2887.0*um"/>
+                    </ring>
+                    <ring id="15" phi0="0.000000*rad" nModules="96">
+                        <modules>
+                            <moduleOdd id="1" X="1444.226*mm" Y="0.000*mm" Z="2622.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="1441.134*mm" Y="94.457*mm" Z="2617.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="2887.0*um"/>
+                    </ring>
+                    <ring id="16" phi0="0.000000*rad" nModules="96">
+                        <modules>
+                            <moduleOdd id="1" X="1522.422*mm" Y="0.000*mm" Z="2632.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="1519.162*mm" Y="99.571*mm" Z="2627.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="52.000*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="52.000*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="2887.0*um"/>
+                    </ring>
+                </rings>
+            </discZPls>
+            <discZPls id="2" z="2986.053*mm" zmin="2976.759*mm" zmax="2995.346*mm" rmin="25.000*mm" rmax="1549.268*mm" bigDelta="5.000*mm">
+                <rings repeat="16" smallDelta="2.500*mm" rPhiOverlap="0.500*mm" nRPhiSegments="4" rOverlap="0.500*mm"/>
+            </discZPls>
+            <discZPls id="3" z="3396.766*mm" zmin="3387.472*mm" zmax="3406.059*mm" rmin="25.000*mm" rmax="1549.268*mm" bigDelta="5.000*mm">
+                <rings repeat="16" smallDelta="2.500*mm" rPhiOverlap="0.500*mm" nRPhiSegments="4" rOverlap="0.500*mm"/>
+            </discZPls>
+            <discZPls id="4" z="3863.970*mm" zmin="3854.676*mm" zmax="3873.263*mm" rmin="25.000*mm" rmax="1549.268*mm" bigDelta="5.000*mm">
+                <rings repeat="16" smallDelta="2.500*mm" rPhiOverlap="0.500*mm" nRPhiSegments="4" rOverlap="0.500*mm"/>
+            </discZPls>
+            <discZPls id="5" z="4395.435*mm" zmin="4386.142*mm" zmax="4404.729*mm" rmin="25.000*mm" rmax="1549.268*mm" bigDelta="5.000*mm">
+                <rings repeat="16" smallDelta="2.500*mm" rPhiOverlap="0.500*mm" nRPhiSegments="4" rOverlap="0.500*mm"/>
+            </discZPls>
+            <discZPls id="6" z="5000.000*mm" zmin="4990.707*mm" zmax="5009.294*mm" rmin="25.000*mm" rmax="1549.268*mm" bigDelta="5.000*mm">
+                <rings repeat="16" smallDelta="2.500*mm" rPhiOverlap="0.500*mm" nRPhiSegments="4" rOverlap="0.500*mm"/>
+            </discZPls>
+        </discs>
+    </detector>
+    <detector name="OuterECAPneg" id="EndCapTrackerOuter_id + 16" type="TkLayoutEcapTracker" readout="TrackerEndcapReadout">
+        <dimensions rmin="25.000*mm" rmax="1549.268*mm" zmin="2615.706*mm" zmax="5009.294*mm" reflect="true"/>
+        <sensitive type="SimpleTrackerSD"/>
+        <discs repeat="12">
+            <discZPls id="1" z="2625.000*mm" zmin="2615.706*mm" zmax="2634.294*mm" rmin="25.000*mm" rmax="1549.268*mm" bigDelta="5.000*mm">
+                <rings repeat="16" smallDelta="2.500*mm" rPhiOverlap="0.500*mm" nRPhiSegments="4" rOverlap="0.500*mm">
+                    <ring id="1" phi0="0.000000*rad" nModules="12">
+                        <modules>
+                            <moduleOdd id="1" X="62.666*mm" Y="0.000*mm" Z="2622.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="54.270*mm" Y="31.333*mm" Z="2617.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="75.332*mm" modWidthMin="13.935*mm" modWidthMax="55.924*mm" modThickness="2.150*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.330*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.043*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.129*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="0.903*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.645*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="75.332*mm" sensorWidthMin="13.935*mm" sensorWidthMax="55.924*mm" sensorThickness="0.100*mm" resRPhi="7.5*um" resZ="15.0*um"/>
+                    </ring>
+                    <ring id="2" phi0="0.000000*rad" nModules="20">
+                        <modules>
+                            <moduleOdd id="1" X="150.203*mm" Y="0.000*mm" Z="2632.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="142.851*mm" Y="46.415*mm" Z="2627.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="100.543*mm" modWidthMin="32.168*mm" modWidthMax="64.533*mm" modThickness="2.150*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.330*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.043*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.129*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="0.903*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.645*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="100.543*mm" sensorWidthMin="32.168*mm" sensorWidthMax="64.533*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="30.0*um"/>
+                    </ring>
+                    <ring id="3" phi0="0.000000*rad" nModules="32">
+                        <modules>
+                            <moduleOdd id="1" X="250.208*mm" Y="0.000*mm" Z="2622.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="245.400*mm" Y="48.813*mm" Z="2617.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.747*mm" modWidthMin="39.672*mm" modWidthMax="60.172*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.747*mm" sensorWidthMin="39.672*mm" sensorWidthMax="60.172*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="4" phi0="0.000000*rad" nModules="44">
+                        <modules>
+                            <moduleOdd id="1" X="351.448*mm" Y="0.000*mm" Z="2632.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="347.871*mm" Y="50.016*mm" Z="2627.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="100.131*mm" modWidthMin="43.613*mm" modWidthMax="58.103*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="100.131*mm" sensorWidthMin="43.613*mm" sensorWidthMax="58.103*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="5" phi0="0.000000*rad" nModules="52">
+                        <modules>
+                            <moduleOdd id="1" X="451.105*mm" Y="0.000*mm" Z="2622.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="447.816*mm" Y="54.375*mm" Z="2617.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="104.752*mm" modWidthMin="48.739*mm" modWidthMax="61.544*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="104.752*mm" sensorWidthMin="48.739*mm" sensorWidthMax="61.544*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="6" phi0="0.000000*rad" nModules="64">
+                        <modules>
+                            <moduleOdd id="1" X="553.187*mm" Y="0.000*mm" Z="2632.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="550.523*mm" Y="54.222*mm" Z="2627.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="99.406*mm" modWidthMin="49.970*mm" modWidthMax="59.836*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="99.406*mm" sensorWidthMin="49.970*mm" sensorWidthMax="59.836*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="7" phi0="0.000000*rad" nModules="44">
+                        <modules>
+                            <moduleOdd id="1" X="650.158*mm" Y="0.000*mm" Z="2622.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="643.540*mm" Y="92.527*mm" Z="2617.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="8" phi0="0.000000*rad" nModules="52">
+                        <modules>
+                            <moduleOdd id="1" X="752.759*mm" Y="0.000*mm" Z="2632.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="747.270*mm" Y="90.735*mm" Z="2627.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="9" phi0="0.000000*rad" nModules="56">
+                        <modules>
+                            <moduleOdd id="1" X="850.081*mm" Y="0.000*mm" Z="2622.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="844.736*mm" Y="95.179*mm" Z="2617.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="10" phi0="0.000000*rad" nModules="64">
+                        <modules>
+                            <moduleOdd id="1" X="952.882*mm" Y="0.000*mm" Z="2632.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="948.294*mm" Y="93.399*mm" Z="2627.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="2887.0*um"/>
+                    </ring>
+                    <ring id="11" phi0="0.000000*rad" nModules="68">
+                        <modules>
+                            <moduleOdd id="1" X="1049.064*mm" Y="0.000*mm" Z="2622.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="1044.589*mm" Y="96.795*mm" Z="2617.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="2887.0*um"/>
+                    </ring>
+                    <ring id="12" phi0="0.000000*rad" nModules="76">
+                        <modules>
+                            <moduleOdd id="1" X="1152.064*mm" Y="0.000*mm" Z="2632.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="1148.129*mm" Y="95.137*mm" Z="2627.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="2887.0*um"/>
+                    </ring>
+                    <ring id="13" phi0="0.000000*rad" nModules="84">
+                        <modules>
+                            <moduleOdd id="1" X="1247.111*mm" Y="0.000*mm" Z="2622.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="1243.623*mm" Y="93.197*mm" Z="2617.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="2887.0*um"/>
+                    </ring>
+                    <ring id="14" phi0="0.000000*rad" nModules="88">
+                        <modules>
+                            <moduleOdd id="1" X="1350.309*mm" Y="0.000*mm" Z="2632.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="1346.869*mm" Y="96.330*mm" Z="2627.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="2887.0*um"/>
+                    </ring>
+                    <ring id="15" phi0="0.000000*rad" nModules="96">
+                        <modules>
+                            <moduleOdd id="1" X="1444.226*mm" Y="0.000*mm" Z="2622.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="1441.134*mm" Y="94.457*mm" Z="2617.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="2887.0*um"/>
+                    </ring>
+                    <ring id="16" phi0="0.000000*rad" nModules="96">
+                        <modules>
+                            <moduleOdd id="1" X="1522.422*mm" Y="0.000*mm" Z="2632.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="1519.162*mm" Y="99.571*mm" Z="2627.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="52.000*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="52.000*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="2887.0*um"/>
+                    </ring>
+                </rings>
+            </discZPls>
+            <discZPls id="2" z="2986.053*mm" zmin="2976.759*mm" zmax="2995.346*mm" rmin="25.000*mm" rmax="1549.268*mm" bigDelta="5.000*mm">
+                <rings repeat="16" smallDelta="2.500*mm" rPhiOverlap="0.500*mm" nRPhiSegments="4" rOverlap="0.500*mm"/>
+            </discZPls>
+            <discZPls id="3" z="3396.766*mm" zmin="3387.472*mm" zmax="3406.059*mm" rmin="25.000*mm" rmax="1549.268*mm" bigDelta="5.000*mm">
+                <rings repeat="16" smallDelta="2.500*mm" rPhiOverlap="0.500*mm" nRPhiSegments="4" rOverlap="0.500*mm"/>
+            </discZPls>
+            <discZPls id="4" z="3863.970*mm" zmin="3854.676*mm" zmax="3873.263*mm" rmin="25.000*mm" rmax="1549.268*mm" bigDelta="5.000*mm">
+                <rings repeat="16" smallDelta="2.500*mm" rPhiOverlap="0.500*mm" nRPhiSegments="4" rOverlap="0.500*mm"/>
+            </discZPls>
+            <discZPls id="5" z="4395.435*mm" zmin="4386.142*mm" zmax="4404.729*mm" rmin="25.000*mm" rmax="1549.268*mm" bigDelta="5.000*mm">
+                <rings repeat="16" smallDelta="2.500*mm" rPhiOverlap="0.500*mm" nRPhiSegments="4" rOverlap="0.500*mm"/>
+            </discZPls>
+            <discZPls id="6" z="5000.000*mm" zmin="4990.707*mm" zmax="5009.294*mm" rmin="25.000*mm" rmax="1549.268*mm" bigDelta="5.000*mm">
+                <rings repeat="16" smallDelta="2.500*mm" rPhiOverlap="0.500*mm" nRPhiSegments="4" rOverlap="0.500*mm"/>
+            </discZPls>
+        </discs>
+    </detector>
+    <detector name="FwdIECAPpos" id="29" type="TkLayoutConicalEcapTracker" readout="TrackerEndcapReadout">
+        <dimensions rmin1="25.000*mm" rmax1="943*mm" rmin2="25.000*mm" rmax2="1342*mm" zmin="6231.066*mm" zmax="8769.293*mm" reflect="false"/>
+        <sensitive type="SimpleTrackerSD"/>
+        <discs repeat="6">
+            <discZPls id="1" z="6250.000*mm" zmin="6241.066*mm" zmax="6258.934*mm" rmin="25.000*mm" rmax="918.570*mm" bigDelta="5.000*mm">
+                <rings repeat="9" smallDelta="2.500*mm" rPhiOverlap="0.500*mm" nRPhiSegments="4" rOverlap="0.500*mm">
+                    <ring id="1" phi0="0.000000*rad" nModules="12">
+                        <modules>
+                            <moduleOdd id="1" X="70.594*mm" Y="0.000*mm" Z="6247.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="61.136*mm" Y="35.297*mm" Z="6242.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="91.188*mm" modWidthMin="13.935*mm" modWidthMax="64.762*mm" modThickness="2.150*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.330*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.043*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.129*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="0.903*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.645*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="91.188*mm" sensorWidthMin="13.935*mm" sensorWidthMax="64.762*mm" sensorThickness="0.100*mm" resRPhi="7.5*um" resZ="15.0*um"/>
+                    </ring>
+                    <ring id="2" phi0="0.000000*rad" nModules="20">
+                        <modules>
+                            <moduleOdd id="1" X="166.145*mm" Y="0.000*mm" Z="6257.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="158.013*mm" Y="51.342*mm" Z="6252.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="100.782*mm" modWidthMin="37.180*mm" modWidthMax="69.551*mm" modThickness="2.150*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.330*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.043*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.129*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="0.903*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.645*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="100.782*mm" sensorWidthMin="37.180*mm" sensorWidthMax="69.551*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="30.0*um"/>
+                    </ring>
+                    <ring id="3" phi0="0.000000*rad" nModules="32">
+                        <modules>
+                            <moduleOdd id="1" X="265.730*mm" Y="0.000*mm" Z="6247.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="260.625*mm" Y="51.841*mm" Z="6242.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="100.425*mm" modWidthMin="42.958*mm" modWidthMax="62.976*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="100.425*mm" sensorWidthMin="42.958*mm" sensorWidthMax="62.976*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="4" phi0="0.000000*rad" nModules="44">
+                        <modules>
+                            <moduleOdd id="1" X="365.777*mm" Y="0.000*mm" Z="6257.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="362.054*mm" Y="52.056*mm" Z="6252.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="100.307*mm" modWidthMin="45.650*mm" modWidthMax="60.158*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="100.307*mm" sensorWidthMin="45.650*mm" sensorWidthMax="60.158*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="5" phi0="0.000000*rad" nModules="56">
+                        <modules>
+                            <moduleOdd id="1" X="464.528*mm" Y="0.000*mm" Z="6247.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="461.607*mm" Y="52.011*mm" Z="6242.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="100.185*mm" modWidthMin="47.050*mm" modWidthMax="58.424*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="100.185*mm" sensorWidthMin="47.050*mm" sensorWidthMax="58.424*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="6" phi0="0.000000*rad" nModules="64">
+                        <modules>
+                            <moduleOdd id="1" X="564.439*mm" Y="0.000*mm" Z="6257.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="561.721*mm" Y="55.325*mm" Z="6252.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="100.049*mm" modWidthMin="51.044*mm" modWidthMax="60.972*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="100.049*mm" sensorWidthMin="51.044*mm" sensorWidthMax="60.972*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="7" phi0="0.000000*rad" nModules="48">
+                        <modules>
+                            <moduleOdd id="1" X="663.691*mm" Y="0.000*mm" Z="6247.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="658.013*mm" Y="86.629*mm" Z="6242.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="8" phi0="0.000000*rad" nModules="52">
+                        <modules>
+                            <moduleOdd id="1" X="766.000*mm" Y="0.000*mm" Z="6257.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="760.415*mm" Y="92.331*mm" Z="6252.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="9" phi0="0.000000*rad" nModules="60">
+                        <modules>
+                            <moduleOdd id="1" X="865.942*mm" Y="0.000*mm" Z="6247.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="861.198*mm" Y="90.516*mm" Z="6242.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                </rings>
+            </discZPls>
+            <discZPls id="2" z="7395.100*mm" zmin="7385.806*mm" zmax="7404.393*mm" rmin="25.000*mm" rmax="1120.194*mm" bigDelta="5.000*mm">
+                <rings repeat="11" smallDelta="2.500*mm" rPhiOverlap="0.500*mm" nRPhiSegments="4" rOverlap="0.500*mm">
+                    <ring id="1" phi0="0.000000*rad" nModules="12">
+                        <modules>
+                            <moduleOdd id="1" X="70.594*mm" Y="0.000*mm" Z="7392.600*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="61.136*mm" Y="35.297*mm" Z="7387.600*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="91.188*mm" modWidthMin="13.935*mm" modWidthMax="64.762*mm" modThickness="2.150*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.330*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.043*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.129*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="0.903*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.645*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="91.188*mm" sensorWidthMin="13.935*mm" sensorWidthMax="64.762*mm" sensorThickness="0.100*mm" resRPhi="7.5*um" resZ="15.0*um"/>
+                    </ring>
+                    <ring id="2" phi0="0.000000*rad" nModules="20">
+                        <modules>
+                            <moduleOdd id="1" X="166.145*mm" Y="0.000*mm" Z="7402.600*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="158.013*mm" Y="51.342*mm" Z="7397.600*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="100.782*mm" modWidthMin="37.180*mm" modWidthMax="69.551*mm" modThickness="2.150*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.330*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.043*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.129*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="0.903*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.645*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="100.782*mm" sensorWidthMin="37.180*mm" sensorWidthMax="69.551*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="30.0*um"/>
+                    </ring>
+                    <ring id="3" phi0="0.000000*rad" nModules="32">
+                        <modules>
+                            <moduleOdd id="1" X="265.730*mm" Y="0.000*mm" Z="7392.600*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="260.625*mm" Y="51.841*mm" Z="7387.600*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="100.425*mm" modWidthMin="42.958*mm" modWidthMax="62.976*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="100.425*mm" sensorWidthMin="42.958*mm" sensorWidthMax="62.976*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="4" phi0="0.000000*rad" nModules="44">
+                        <modules>
+                            <moduleOdd id="1" X="365.777*mm" Y="0.000*mm" Z="7402.600*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="362.054*mm" Y="52.056*mm" Z="7397.600*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="100.307*mm" modWidthMin="45.650*mm" modWidthMax="60.158*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="100.307*mm" sensorWidthMin="45.650*mm" sensorWidthMax="60.158*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="5" phi0="0.000000*rad" nModules="56">
+                        <modules>
+                            <moduleOdd id="1" X="464.528*mm" Y="0.000*mm" Z="7392.600*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="461.607*mm" Y="52.011*mm" Z="7387.600*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="100.185*mm" modWidthMin="47.050*mm" modWidthMax="58.424*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="100.185*mm" sensorWidthMin="47.050*mm" sensorWidthMax="58.424*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="6" phi0="0.000000*rad" nModules="64">
+                        <modules>
+                            <moduleOdd id="1" X="564.439*mm" Y="0.000*mm" Z="7402.600*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="561.721*mm" Y="55.325*mm" Z="7397.600*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="100.049*mm" modWidthMin="51.044*mm" modWidthMax="60.972*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="100.049*mm" sensorWidthMin="51.044*mm" sensorWidthMax="60.972*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="7" phi0="0.000000*rad" nModules="48">
+                        <modules>
+                            <moduleOdd id="1" X="663.691*mm" Y="0.000*mm" Z="7392.600*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="658.013*mm" Y="86.629*mm" Z="7387.600*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="8" phi0="0.000000*rad" nModules="52">
+                        <modules>
+                            <moduleOdd id="1" X="766.000*mm" Y="0.000*mm" Z="7402.600*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="760.415*mm" Y="92.331*mm" Z="7397.600*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="9" phi0="0.000000*rad" nModules="60">
+                        <modules>
+                            <moduleOdd id="1" X="865.942*mm" Y="0.000*mm" Z="7392.600*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="861.198*mm" Y="90.516*mm" Z="7387.600*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="10" phi0="0.000000*rad" nModules="64">
+                        <modules>
+                            <moduleOdd id="1" X="968.366*mm" Y="0.000*mm" Z="7402.600*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="963.703*mm" Y="94.916*mm" Z="7397.600*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="2887.0*um"/>
+                    </ring>
+                    <ring id="11" phi0="0.000000*rad" nModules="72">
+                        <modules>
+                            <moduleOdd id="1" X="1067.823*mm" Y="0.000*mm" Z="7392.600*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="1063.760*mm" Y="93.067*mm" Z="7387.600*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="2887.0*um"/>
+                    </ring>
+                </rings>
+            </discZPls>
+            <discZPls id="3" z="8750.000*mm" zmin="8740.707*mm" zmax="8759.293*mm" rmin="25.000*mm" rmax="1321.527*mm" bigDelta="5.000*mm">
+                <rings repeat="13" smallDelta="2.500*mm" rPhiOverlap="0.500*mm" nRPhiSegments="4" rOverlap="0.500*mm">
+                    <ring id="1" phi0="0.000000*rad" nModules="12">
+                        <modules>
+                            <moduleOdd id="1" X="70.594*mm" Y="0.000*mm" Z="8747.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="61.136*mm" Y="35.297*mm" Z="8742.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="91.188*mm" modWidthMin="13.935*mm" modWidthMax="64.762*mm" modThickness="2.150*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.330*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.043*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.129*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="0.903*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.645*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="91.188*mm" sensorWidthMin="13.935*mm" sensorWidthMax="64.762*mm" sensorThickness="0.100*mm" resRPhi="7.5*um" resZ="15.0*um"/>
+                    </ring>
+                    <ring id="2" phi0="0.000000*rad" nModules="20">
+                        <modules>
+                            <moduleOdd id="1" X="166.145*mm" Y="0.000*mm" Z="8757.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="158.013*mm" Y="51.342*mm" Z="8752.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="100.782*mm" modWidthMin="37.180*mm" modWidthMax="69.551*mm" modThickness="2.150*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.330*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.043*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.129*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="0.903*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.645*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="100.782*mm" sensorWidthMin="37.180*mm" sensorWidthMax="69.551*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="30.0*um"/>
+                    </ring>
+                    <ring id="3" phi0="0.000000*rad" nModules="32">
+                        <modules>
+                            <moduleOdd id="1" X="265.730*mm" Y="0.000*mm" Z="8747.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="260.625*mm" Y="51.841*mm" Z="8742.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="100.425*mm" modWidthMin="42.958*mm" modWidthMax="62.976*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="100.425*mm" sensorWidthMin="42.958*mm" sensorWidthMax="62.976*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="4" phi0="0.000000*rad" nModules="44">
+                        <modules>
+                            <moduleOdd id="1" X="365.777*mm" Y="0.000*mm" Z="8757.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="362.054*mm" Y="52.056*mm" Z="8752.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="100.307*mm" modWidthMin="45.650*mm" modWidthMax="60.158*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="100.307*mm" sensorWidthMin="45.650*mm" sensorWidthMax="60.158*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="5" phi0="0.000000*rad" nModules="56">
+                        <modules>
+                            <moduleOdd id="1" X="464.528*mm" Y="0.000*mm" Z="8747.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="461.607*mm" Y="52.011*mm" Z="8742.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="100.185*mm" modWidthMin="47.050*mm" modWidthMax="58.424*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="100.185*mm" sensorWidthMin="47.050*mm" sensorWidthMax="58.424*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="6" phi0="0.000000*rad" nModules="64">
+                        <modules>
+                            <moduleOdd id="1" X="564.439*mm" Y="0.000*mm" Z="8757.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="561.721*mm" Y="55.325*mm" Z="8752.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="100.049*mm" modWidthMin="51.044*mm" modWidthMax="60.972*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="100.049*mm" sensorWidthMin="51.044*mm" sensorWidthMax="60.972*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="7" phi0="0.000000*rad" nModules="48">
+                        <modules>
+                            <moduleOdd id="1" X="663.691*mm" Y="0.000*mm" Z="8747.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="658.013*mm" Y="86.629*mm" Z="8742.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="8" phi0="0.000000*rad" nModules="52">
+                        <modules>
+                            <moduleOdd id="1" X="766.000*mm" Y="0.000*mm" Z="8757.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="760.415*mm" Y="92.331*mm" Z="8752.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="9" phi0="0.000000*rad" nModules="60">
+                        <modules>
+                            <moduleOdd id="1" X="865.942*mm" Y="0.000*mm" Z="8747.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="861.198*mm" Y="90.516*mm" Z="8742.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="10" phi0="0.000000*rad" nModules="64">
+                        <modules>
+                            <moduleOdd id="1" X="968.366*mm" Y="0.000*mm" Z="8757.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="963.703*mm" Y="94.916*mm" Z="8752.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="2887.0*um"/>
+                    </ring>
+                    <ring id="11" phi0="0.000000*rad" nModules="72">
+                        <modules>
+                            <moduleOdd id="1" X="1067.823*mm" Y="0.000*mm" Z="8747.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="1063.760*mm" Y="93.067*mm" Z="8742.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="2887.0*um"/>
+                    </ring>
+                    <ring id="12" phi0="0.000000*rad" nModules="76">
+                        <modules>
+                            <moduleOdd id="1" X="1170.362*mm" Y="0.000*mm" Z="8757.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="1166.365*mm" Y="96.648*mm" Z="8752.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="2887.0*um"/>
+                    </ring>
+                    <ring id="13" phi0="0.000000*rad" nModules="84">
+                        <modules>
+                            <moduleOdd id="1" X="1269.335*mm" Y="0.000*mm" Z="8747.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="1265.786*mm" Y="94.858*mm" Z="8742.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="2887.0*um"/>
+                    </ring>
+                </rings>
+            </discZPls>
+        </discs>
+    </detector>
+    <detector name="FwdIECAPneg" id="30" type="TkLayoutConicalEcapTracker" readout="TrackerEndcapReadout">
+        <dimensions rmin1="25.000*mm" rmax1="943*mm" rmin2="25.000*mm" rmax2="1344*mm" zmin="6231.066*mm" zmax="8769.293*mm" reflect="true"/>
+        <sensitive type="SimpleTrackerSD"/>
+        <discs repeat="6">
+            <discZPls id="1" z="6250.000*mm" zmin="6241.066*mm" zmax="6258.934*mm" rmin="25.000*mm" rmax="918.570*mm" bigDelta="5.000*mm">
+                <rings repeat="9" smallDelta="2.500*mm" rPhiOverlap="0.500*mm" nRPhiSegments="4" rOverlap="0.500*mm">
+                    <ring id="1" phi0="0.000000*rad" nModules="12">
+                        <modules>
+                            <moduleOdd id="1" X="70.594*mm" Y="0.000*mm" Z="6247.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="61.136*mm" Y="35.297*mm" Z="6242.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="91.188*mm" modWidthMin="13.935*mm" modWidthMax="64.762*mm" modThickness="2.150*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.330*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.043*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.129*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="0.903*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.645*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="91.188*mm" sensorWidthMin="13.935*mm" sensorWidthMax="64.762*mm" sensorThickness="0.100*mm" resRPhi="7.5*um" resZ="15.0*um"/>
+                    </ring>
+                    <ring id="2" phi0="0.000000*rad" nModules="20">
+                        <modules>
+                            <moduleOdd id="1" X="166.145*mm" Y="0.000*mm" Z="6257.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="158.013*mm" Y="51.342*mm" Z="6252.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="100.782*mm" modWidthMin="37.180*mm" modWidthMax="69.551*mm" modThickness="2.150*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.330*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.043*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.129*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="0.903*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.645*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="100.782*mm" sensorWidthMin="37.180*mm" sensorWidthMax="69.551*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="30.0*um"/>
+                    </ring>
+                    <ring id="3" phi0="0.000000*rad" nModules="32">
+                        <modules>
+                            <moduleOdd id="1" X="265.730*mm" Y="0.000*mm" Z="6247.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="260.625*mm" Y="51.841*mm" Z="6242.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="100.425*mm" modWidthMin="42.958*mm" modWidthMax="62.976*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="100.425*mm" sensorWidthMin="42.958*mm" sensorWidthMax="62.976*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="4" phi0="0.000000*rad" nModules="44">
+                        <modules>
+                            <moduleOdd id="1" X="365.777*mm" Y="0.000*mm" Z="6257.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="362.054*mm" Y="52.056*mm" Z="6252.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="100.307*mm" modWidthMin="45.650*mm" modWidthMax="60.158*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="100.307*mm" sensorWidthMin="45.650*mm" sensorWidthMax="60.158*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="5" phi0="0.000000*rad" nModules="56">
+                        <modules>
+                            <moduleOdd id="1" X="464.528*mm" Y="0.000*mm" Z="6247.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="461.607*mm" Y="52.011*mm" Z="6242.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="100.185*mm" modWidthMin="47.050*mm" modWidthMax="58.424*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="100.185*mm" sensorWidthMin="47.050*mm" sensorWidthMax="58.424*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="6" phi0="0.000000*rad" nModules="64">
+                        <modules>
+                            <moduleOdd id="1" X="564.439*mm" Y="0.000*mm" Z="6257.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="561.721*mm" Y="55.325*mm" Z="6252.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="100.049*mm" modWidthMin="51.044*mm" modWidthMax="60.972*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="100.049*mm" sensorWidthMin="51.044*mm" sensorWidthMax="60.972*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="7" phi0="0.000000*rad" nModules="48">
+                        <modules>
+                            <moduleOdd id="1" X="663.691*mm" Y="0.000*mm" Z="6247.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="658.013*mm" Y="86.629*mm" Z="6242.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="8" phi0="0.000000*rad" nModules="52">
+                        <modules>
+                            <moduleOdd id="1" X="766.000*mm" Y="0.000*mm" Z="6257.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="760.415*mm" Y="92.331*mm" Z="6252.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="9" phi0="0.000000*rad" nModules="60">
+                        <modules>
+                            <moduleOdd id="1" X="865.942*mm" Y="0.000*mm" Z="6247.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="861.198*mm" Y="90.516*mm" Z="6242.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                </rings>
+            </discZPls>
+            <discZPls id="2" z="7395.100*mm" zmin="7385.806*mm" zmax="7404.393*mm" rmin="25.000*mm" rmax="1120.194*mm" bigDelta="5.000*mm">
+                <rings repeat="11" smallDelta="2.500*mm" rPhiOverlap="0.500*mm" nRPhiSegments="4" rOverlap="0.500*mm">
+                    <ring id="1" phi0="0.000000*rad" nModules="12">
+                        <modules>
+                            <moduleOdd id="1" X="70.594*mm" Y="0.000*mm" Z="7392.600*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="61.136*mm" Y="35.297*mm" Z="7387.600*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="91.188*mm" modWidthMin="13.935*mm" modWidthMax="64.762*mm" modThickness="2.150*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.330*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.043*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.129*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="0.903*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.645*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="91.188*mm" sensorWidthMin="13.935*mm" sensorWidthMax="64.762*mm" sensorThickness="0.100*mm" resRPhi="7.5*um" resZ="15.0*um"/>
+                    </ring>
+                    <ring id="2" phi0="0.000000*rad" nModules="20">
+                        <modules>
+                            <moduleOdd id="1" X="166.145*mm" Y="0.000*mm" Z="7402.600*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="158.013*mm" Y="51.342*mm" Z="7397.600*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="100.782*mm" modWidthMin="37.180*mm" modWidthMax="69.551*mm" modThickness="2.150*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.330*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.043*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.129*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="0.903*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.645*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="100.782*mm" sensorWidthMin="37.180*mm" sensorWidthMax="69.551*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="30.0*um"/>
+                    </ring>
+                    <ring id="3" phi0="0.000000*rad" nModules="32">
+                        <modules>
+                            <moduleOdd id="1" X="265.730*mm" Y="0.000*mm" Z="7392.600*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="260.625*mm" Y="51.841*mm" Z="7387.600*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="100.425*mm" modWidthMin="42.958*mm" modWidthMax="62.976*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="100.425*mm" sensorWidthMin="42.958*mm" sensorWidthMax="62.976*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="4" phi0="0.000000*rad" nModules="44">
+                        <modules>
+                            <moduleOdd id="1" X="365.777*mm" Y="0.000*mm" Z="7402.600*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="362.054*mm" Y="52.056*mm" Z="7397.600*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="100.307*mm" modWidthMin="45.650*mm" modWidthMax="60.158*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="100.307*mm" sensorWidthMin="45.650*mm" sensorWidthMax="60.158*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="5" phi0="0.000000*rad" nModules="56">
+                        <modules>
+                            <moduleOdd id="1" X="464.528*mm" Y="0.000*mm" Z="7392.600*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="461.607*mm" Y="52.011*mm" Z="7387.600*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="100.185*mm" modWidthMin="47.050*mm" modWidthMax="58.424*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="100.185*mm" sensorWidthMin="47.050*mm" sensorWidthMax="58.424*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="6" phi0="0.000000*rad" nModules="64">
+                        <modules>
+                            <moduleOdd id="1" X="564.439*mm" Y="0.000*mm" Z="7402.600*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="561.721*mm" Y="55.325*mm" Z="7397.600*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="100.049*mm" modWidthMin="51.044*mm" modWidthMax="60.972*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="100.049*mm" sensorWidthMin="51.044*mm" sensorWidthMax="60.972*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="7" phi0="0.000000*rad" nModules="48">
+                        <modules>
+                            <moduleOdd id="1" X="663.691*mm" Y="0.000*mm" Z="7392.600*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="658.013*mm" Y="86.629*mm" Z="7387.600*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="8" phi0="0.000000*rad" nModules="52">
+                        <modules>
+                            <moduleOdd id="1" X="766.000*mm" Y="0.000*mm" Z="7402.600*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="760.415*mm" Y="92.331*mm" Z="7397.600*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="9" phi0="0.000000*rad" nModules="60">
+                        <modules>
+                            <moduleOdd id="1" X="865.942*mm" Y="0.000*mm" Z="7392.600*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="861.198*mm" Y="90.516*mm" Z="7387.600*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="10" phi0="0.000000*rad" nModules="64">
+                        <modules>
+                            <moduleOdd id="1" X="968.366*mm" Y="0.000*mm" Z="7402.600*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="963.703*mm" Y="94.916*mm" Z="7397.600*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="2887.0*um"/>
+                    </ring>
+                    <ring id="11" phi0="0.000000*rad" nModules="72">
+                        <modules>
+                            <moduleOdd id="1" X="1067.823*mm" Y="0.000*mm" Z="7392.600*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="1063.760*mm" Y="93.067*mm" Z="7387.600*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="2887.0*um"/>
+                    </ring>
+                </rings>
+            </discZPls>
+            <discZPls id="3" z="8750.000*mm" zmin="8740.707*mm" zmax="8759.293*mm" rmin="25.000*mm" rmax="1321.527*mm" bigDelta="5.000*mm">
+                <rings repeat="13" smallDelta="2.500*mm" rPhiOverlap="0.500*mm" nRPhiSegments="4" rOverlap="0.500*mm">
+                    <ring id="1" phi0="0.000000*rad" nModules="12">
+                        <modules>
+                            <moduleOdd id="1" X="70.594*mm" Y="0.000*mm" Z="8747.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="61.136*mm" Y="35.297*mm" Z="8742.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="91.188*mm" modWidthMin="13.935*mm" modWidthMax="64.762*mm" modThickness="2.150*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.330*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.043*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.129*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="0.903*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.645*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="91.188*mm" sensorWidthMin="13.935*mm" sensorWidthMax="64.762*mm" sensorThickness="0.100*mm" resRPhi="7.5*um" resZ="15.0*um"/>
+                    </ring>
+                    <ring id="2" phi0="0.000000*rad" nModules="20">
+                        <modules>
+                            <moduleOdd id="1" X="166.145*mm" Y="0.000*mm" Z="8757.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="158.013*mm" Y="51.342*mm" Z="8752.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="100.782*mm" modWidthMin="37.180*mm" modWidthMax="69.551*mm" modThickness="2.150*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.330*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.043*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.129*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="0.903*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.645*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="100.782*mm" sensorWidthMin="37.180*mm" sensorWidthMax="69.551*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="30.0*um"/>
+                    </ring>
+                    <ring id="3" phi0="0.000000*rad" nModules="32">
+                        <modules>
+                            <moduleOdd id="1" X="265.730*mm" Y="0.000*mm" Z="8747.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="260.625*mm" Y="51.841*mm" Z="8742.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="100.425*mm" modWidthMin="42.958*mm" modWidthMax="62.976*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="100.425*mm" sensorWidthMin="42.958*mm" sensorWidthMax="62.976*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="4" phi0="0.000000*rad" nModules="44">
+                        <modules>
+                            <moduleOdd id="1" X="365.777*mm" Y="0.000*mm" Z="8757.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="362.054*mm" Y="52.056*mm" Z="8752.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="100.307*mm" modWidthMin="45.650*mm" modWidthMax="60.158*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="100.307*mm" sensorWidthMin="45.650*mm" sensorWidthMax="60.158*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="5" phi0="0.000000*rad" nModules="56">
+                        <modules>
+                            <moduleOdd id="1" X="464.528*mm" Y="0.000*mm" Z="8747.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="461.607*mm" Y="52.011*mm" Z="8742.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="100.185*mm" modWidthMin="47.050*mm" modWidthMax="58.424*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="100.185*mm" sensorWidthMin="47.050*mm" sensorWidthMax="58.424*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="6" phi0="0.000000*rad" nModules="64">
+                        <modules>
+                            <moduleOdd id="1" X="564.439*mm" Y="0.000*mm" Z="8757.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="561.721*mm" Y="55.325*mm" Z="8752.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="100.049*mm" modWidthMin="51.044*mm" modWidthMax="60.972*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="100.049*mm" sensorWidthMin="51.044*mm" sensorWidthMax="60.972*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="7" phi0="0.000000*rad" nModules="48">
+                        <modules>
+                            <moduleOdd id="1" X="663.691*mm" Y="0.000*mm" Z="8747.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="658.013*mm" Y="86.629*mm" Z="8742.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="8" phi0="0.000000*rad" nModules="52">
+                        <modules>
+                            <moduleOdd id="1" X="766.000*mm" Y="0.000*mm" Z="8757.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="760.415*mm" Y="92.331*mm" Z="8752.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="9" phi0="0.000000*rad" nModules="60">
+                        <modules>
+                            <moduleOdd id="1" X="865.942*mm" Y="0.000*mm" Z="8747.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="861.198*mm" Y="90.516*mm" Z="8742.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="10" phi0="0.000000*rad" nModules="64">
+                        <modules>
+                            <moduleOdd id="1" X="968.366*mm" Y="0.000*mm" Z="8757.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="963.703*mm" Y="94.916*mm" Z="8752.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="2887.0*um"/>
+                    </ring>
+                    <ring id="11" phi0="0.000000*rad" nModules="72">
+                        <modules>
+                            <moduleOdd id="1" X="1067.823*mm" Y="0.000*mm" Z="8747.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="1063.760*mm" Y="93.067*mm" Z="8742.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="2887.0*um"/>
+                    </ring>
+                    <ring id="12" phi0="0.000000*rad" nModules="76">
+                        <modules>
+                            <moduleOdd id="1" X="1170.362*mm" Y="0.000*mm" Z="8757.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="1166.365*mm" Y="96.648*mm" Z="8752.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="2887.0*um"/>
+                    </ring>
+                    <ring id="13" phi0="0.000000*rad" nModules="84">
+                        <modules>
+                            <moduleOdd id="1" X="1269.335*mm" Y="0.000*mm" Z="8747.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="1265.786*mm" Y="94.858*mm" Z="8742.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="2887.0*um"/>
+                    </ring>
+                </rings>
+            </discZPls>
+        </discs>
+    </detector>
+    <detector name="FwdECAPpos" id="27" type="TkLayoutEcapTracker" readout="TrackerEndcapReadout">
+        <dimensions rmin="49.500*mm" rmax="1550.163*mm" zmin="9990.707*mm" zmax="16009.294*mm" reflect="false"/>
+        <sensitive type="SimpleTrackerSD"/>
+        <discs repeat="12">
+            <discZPls id="1" z="10000.000*mm" zmin="9990.707*mm" zmax="10009.293*mm" rmin="49.500*mm" rmax="1550.163*mm" bigDelta="5.000*mm">
+                <rings repeat="15" smallDelta="2.500*mm" rPhiOverlap="0.500*mm" nRPhiSegments="4" rOverlap="0.500*mm">
+                    <ring id="1" phi0="0.000000*rad" nModules="12">
+                        <modules>
+                            <moduleOdd id="1" X="94.508*mm" Y="0.000*mm" Z="9997.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="81.846*mm" Y="47.254*mm" Z="9992.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="90.016*mm" modWidthMin="27.064*mm" modWidthMax="76.279*mm" modThickness="2.150*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.330*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.043*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.129*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="0.903*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.645*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="90.016*mm" sensorWidthMin="27.064*mm" sensorWidthMax="76.279*mm" sensorThickness="0.100*mm" resRPhi="7.5*um" resZ="15.0*um"/>
+                    </ring>
+                    <ring id="2" phi0="0.000000*rad" nModules="24">
+                        <modules>
+                            <moduleOdd id="1" X="189.080*mm" Y="0.000*mm" Z="10007.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="182.638*mm" Y="48.938*mm" Z="10002.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="100.043*mm" modWidthMin="37.124*mm" modWidthMax="63.832*mm" modThickness="2.150*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.330*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.043*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.129*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="0.903*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.645*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="100.043*mm" sensorWidthMin="37.124*mm" sensorWidthMax="63.832*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="30.0*um"/>
+                    </ring>
+                    <ring id="3" phi0="0.000000*rad" nModules="36">
+                        <modules>
+                            <moduleOdd id="1" X="288.237*mm" Y="0.000*mm" Z="9997.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="283.858*mm" Y="50.052*mm" Z="9992.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="99.985*mm" modWidthMin="42.191*mm" modWidthMax="59.898*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="99.985*mm" sensorWidthMin="42.191*mm" sensorWidthMax="59.898*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="4" phi0="0.000000*rad" nModules="48">
+                        <modules>
+                            <moduleOdd id="1" X="387.840*mm" Y="0.000*mm" Z="10007.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="384.522*mm" Y="50.623*mm" Z="10002.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="100.010*mm" modWidthMin="44.788*mm" modWidthMax="58.047*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="100.010*mm" sensorWidthMin="44.788*mm" sensorWidthMax="58.047*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="5" phi0="0.000000*rad" nModules="56">
+                        <modules>
+                            <moduleOdd id="1" X="486.679*mm" Y="0.000*mm" Z="9997.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="483.619*mm" Y="54.491*mm" Z="9992.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="99.980*mm" modWidthMin="49.549*mm" modWidthMax="60.894*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="99.980*mm" sensorWidthMin="49.549*mm" sensorWidthMax="60.894*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="6" phi0="0.000000*rad" nModules="40">
+                        <modules>
+                            <moduleOdd id="1" X="587.536*mm" Y="0.000*mm" Z="10007.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="580.303*mm" Y="91.911*mm" Z="10002.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="7" phi0="0.000000*rad" nModules="48">
+                        <modules>
+                            <moduleOdd id="1" X="688.480*mm" Y="0.000*mm" Z="9997.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="682.590*mm" Y="89.865*mm" Z="9992.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="8" phi0="0.000000*rad" nModules="52">
+                        <modules>
+                            <moduleOdd id="1" X="790.611*mm" Y="0.000*mm" Z="10007.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="784.846*mm" Y="95.298*mm" Z="10002.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="9" phi0="0.000000*rad" nModules="60">
+                        <modules>
+                            <moduleOdd id="1" X="891.250*mm" Y="0.000*mm" Z="9997.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="886.367*mm" Y="93.161*mm" Z="9992.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="10" phi0="0.000000*rad" nModules="68">
+                        <modules>
+                            <moduleOdd id="1" X="993.444*mm" Y="0.000*mm" Z="10007.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="989.206*mm" Y="91.663*mm" Z="10002.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="2887.0*um"/>
+                    </ring>
+                    <ring id="11" phi0="0.000000*rad" nModules="72">
+                        <modules>
+                            <moduleOdd id="1" X="1093.779*mm" Y="0.000*mm" Z="9997.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="1089.617*mm" Y="95.329*mm" Z="9992.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="2887.0*um"/>
+                    </ring>
+                    <ring id="12" phi0="0.000000*rad" nModules="80">
+                        <modules>
+                            <moduleOdd id="1" X="1196.037*mm" Y="0.000*mm" Z="10007.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="1192.350*mm" Y="93.840*mm" Z="10002.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="2887.0*um"/>
+                    </ring>
+                    <ring id="13" phi0="0.000000*rad" nModules="84">
+                        <modules>
+                            <moduleOdd id="1" X="1296.068*mm" Y="0.000*mm" Z="9997.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="1292.444*mm" Y="96.855*mm" Z="9992.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="2887.0*um"/>
+                    </ring>
+                    <ring id="14" phi0="0.000000*rad" nModules="92">
+                        <modules>
+                            <moduleOdd id="1" X="1398.389*mm" Y="0.000*mm" Z="10007.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="1395.129*mm" Y="95.429*mm" Z="10002.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="2887.0*um"/>
+                    </ring>
+                    <ring id="15" phi0="0.000000*rad" nModules="96">
+                        <modules>
+                            <moduleOdd id="1" X="1498.117*mm" Y="0.000*mm" Z="9997.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="1494.909*mm" Y="97.982*mm" Z="9992.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="2887.0*um"/>
+                    </ring>
+                </rings>
+            </discZPls>
+            <discZPls id="2" z="10985.605*mm" zmin="10976.312*mm" zmax="10994.899*mm" rmin="49.500*mm" rmax="1550.163*mm" bigDelta="5.000*mm">
+                <rings repeat="15" smallDelta="2.500*mm" rPhiOverlap="0.500*mm" nRPhiSegments="4" rOverlap="0.500*mm"/>
+            </discZPls>
+            <discZPls id="3" z="12068.353*mm" zmin="12059.059*mm" zmax="12077.646*mm" rmin="49.500*mm" rmax="1550.163*mm" bigDelta="5.000*mm">
+                <rings repeat="15" smallDelta="2.500*mm" rPhiOverlap="0.500*mm" nRPhiSegments="4" rOverlap="0.500*mm"/>
+            </discZPls>
+            <discZPls id="4" z="13257.816*mm" zmin="13248.523*mm" zmax="13267.110*mm" rmin="49.500*mm" rmax="1550.163*mm" bigDelta="5.000*mm">
+                <rings repeat="15" smallDelta="2.500*mm" rPhiOverlap="0.500*mm" nRPhiSegments="4" rOverlap="0.500*mm"/>
+            </discZPls>
+            <discZPls id="5" z="14564.514*mm" zmin="14555.220*mm" zmax="14573.807*mm" rmin="49.500*mm" rmax="1550.163*mm" bigDelta="5.000*mm">
+                <rings repeat="15" smallDelta="2.500*mm" rPhiOverlap="0.500*mm" nRPhiSegments="4" rOverlap="0.500*mm"/>
+            </discZPls>
+            <discZPls id="6" z="16000.000*mm" zmin="15990.707*mm" zmax="16009.294*mm" rmin="49.500*mm" rmax="1550.163*mm" bigDelta="5.000*mm">
+                <rings repeat="15" smallDelta="2.500*mm" rPhiOverlap="0.500*mm" nRPhiSegments="4" rOverlap="0.500*mm"/>
+            </discZPls>
+        </discs>
+    </detector>
+    <detector name="FwdECAPneg" id="28" type="TkLayoutEcapTracker" readout="TrackerEndcapReadout">
+        <dimensions rmin="49.500*mm" rmax="1550.163*mm" zmin="9990.707*mm" zmax="16009.294*mm" reflect="true"/>
+        <sensitive type="SimpleTrackerSD"/>
+        <discs repeat="12">
+            <discZPls id="1" z="10000.000*mm" zmin="9990.707*mm" zmax="10009.293*mm" rmin="49.500*mm" rmax="1550.163*mm" bigDelta="5.000*mm">
+                <rings repeat="15" smallDelta="2.500*mm" rPhiOverlap="0.500*mm" nRPhiSegments="4" rOverlap="0.500*mm">
+                    <ring id="1" phi0="0.000000*rad" nModules="12">
+                        <modules>
+                            <moduleOdd id="1" X="94.508*mm" Y="0.000*mm" Z="9997.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="81.846*mm" Y="47.254*mm" Z="9992.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="90.016*mm" modWidthMin="27.064*mm" modWidthMax="76.279*mm" modThickness="2.150*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.330*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.043*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.129*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="0.903*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.645*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="90.016*mm" sensorWidthMin="27.064*mm" sensorWidthMax="76.279*mm" sensorThickness="0.100*mm" resRPhi="7.5*um" resZ="15.0*um"/>
+                    </ring>
+                    <ring id="2" phi0="0.000000*rad" nModules="24">
+                        <modules>
+                            <moduleOdd id="1" X="189.080*mm" Y="0.000*mm" Z="10007.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="182.638*mm" Y="48.938*mm" Z="10002.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="100.043*mm" modWidthMin="37.124*mm" modWidthMax="63.832*mm" modThickness="2.150*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.330*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.043*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.129*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="0.903*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.645*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="100.043*mm" sensorWidthMin="37.124*mm" sensorWidthMax="63.832*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="30.0*um"/>
+                    </ring>
+                    <ring id="3" phi0="0.000000*rad" nModules="36">
+                        <modules>
+                            <moduleOdd id="1" X="288.237*mm" Y="0.000*mm" Z="9997.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="283.858*mm" Y="50.052*mm" Z="9992.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="99.985*mm" modWidthMin="42.191*mm" modWidthMax="59.898*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="99.985*mm" sensorWidthMin="42.191*mm" sensorWidthMax="59.898*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="4" phi0="0.000000*rad" nModules="48">
+                        <modules>
+                            <moduleOdd id="1" X="387.840*mm" Y="0.000*mm" Z="10007.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="384.522*mm" Y="50.623*mm" Z="10002.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="100.010*mm" modWidthMin="44.788*mm" modWidthMax="58.047*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="100.010*mm" sensorWidthMin="44.788*mm" sensorWidthMax="58.047*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="5" phi0="0.000000*rad" nModules="56">
+                        <modules>
+                            <moduleOdd id="1" X="486.679*mm" Y="0.000*mm" Z="9997.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="483.619*mm" Y="54.491*mm" Z="9992.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="99.980*mm" modWidthMin="49.549*mm" modWidthMax="60.894*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="99.980*mm" sensorWidthMin="49.549*mm" sensorWidthMax="60.894*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="6" phi0="0.000000*rad" nModules="40">
+                        <modules>
+                            <moduleOdd id="1" X="587.536*mm" Y="0.000*mm" Z="10007.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="580.303*mm" Y="91.911*mm" Z="10002.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="7" phi0="0.000000*rad" nModules="48">
+                        <modules>
+                            <moduleOdd id="1" X="688.480*mm" Y="0.000*mm" Z="9997.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="682.590*mm" Y="89.865*mm" Z="9992.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="8" phi0="0.000000*rad" nModules="52">
+                        <modules>
+                            <moduleOdd id="1" X="790.611*mm" Y="0.000*mm" Z="10007.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="784.846*mm" Y="95.298*mm" Z="10002.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="9" phi0="0.000000*rad" nModules="60">
+                        <modules>
+                            <moduleOdd id="1" X="891.250*mm" Y="0.000*mm" Z="9997.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="886.367*mm" Y="93.161*mm" Z="9992.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="10" phi0="0.000000*rad" nModules="68">
+                        <modules>
+                            <moduleOdd id="1" X="993.444*mm" Y="0.000*mm" Z="10007.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="989.206*mm" Y="91.663*mm" Z="10002.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="2887.0*um"/>
+                    </ring>
+                    <ring id="11" phi0="0.000000*rad" nModules="72">
+                        <modules>
+                            <moduleOdd id="1" X="1093.779*mm" Y="0.000*mm" Z="9997.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="1089.617*mm" Y="95.329*mm" Z="9992.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="2887.0*um"/>
+                    </ring>
+                    <ring id="12" phi0="0.000000*rad" nModules="80">
+                        <modules>
+                            <moduleOdd id="1" X="1196.037*mm" Y="0.000*mm" Z="10007.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="1192.350*mm" Y="93.840*mm" Z="10002.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="2887.0*um"/>
+                    </ring>
+                    <ring id="13" phi0="0.000000*rad" nModules="84">
+                        <modules>
+                            <moduleOdd id="1" X="1296.068*mm" Y="0.000*mm" Z="9997.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="1292.444*mm" Y="96.855*mm" Z="9992.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="2887.0*um"/>
+                    </ring>
+                    <ring id="14" phi0="0.000000*rad" nModules="92">
+                        <modules>
+                            <moduleOdd id="1" X="1398.389*mm" Y="0.000*mm" Z="10007.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="1395.129*mm" Y="95.429*mm" Z="10002.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="2887.0*um"/>
+                    </ring>
+                    <ring id="15" phi0="0.000000*rad" nModules="96">
+                        <modules>
+                            <moduleOdd id="1" X="1498.117*mm" Y="0.000*mm" Z="9997.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="1494.909*mm" Y="97.982*mm" Z="9992.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Si" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="2887.0*um"/>
+                    </ring>
+                </rings>
+            </discZPls>
+            <discZPls id="2" z="10985.605*mm" zmin="10976.312*mm" zmax="10994.899*mm" rmin="49.500*mm" rmax="1550.163*mm" bigDelta="5.000*mm">
+                <rings repeat="15" smallDelta="2.500*mm" rPhiOverlap="0.500*mm" nRPhiSegments="4" rOverlap="0.500*mm"/>
+            </discZPls>
+            <discZPls id="3" z="12068.353*mm" zmin="12059.059*mm" zmax="12077.646*mm" rmin="49.500*mm" rmax="1550.163*mm" bigDelta="5.000*mm">
+                <rings repeat="15" smallDelta="2.500*mm" rPhiOverlap="0.500*mm" nRPhiSegments="4" rOverlap="0.500*mm"/>
+            </discZPls>
+            <discZPls id="4" z="13257.816*mm" zmin="13248.523*mm" zmax="13267.110*mm" rmin="49.500*mm" rmax="1550.163*mm" bigDelta="5.000*mm">
+                <rings repeat="15" smallDelta="2.500*mm" rPhiOverlap="0.500*mm" nRPhiSegments="4" rOverlap="0.500*mm"/>
+            </discZPls>
+            <discZPls id="5" z="14564.514*mm" zmin="14555.220*mm" zmax="14573.807*mm" rmin="49.500*mm" rmax="1550.163*mm" bigDelta="5.000*mm">
+                <rings repeat="15" smallDelta="2.500*mm" rPhiOverlap="0.500*mm" nRPhiSegments="4" rOverlap="0.500*mm"/>
+            </discZPls>
+            <discZPls id="6" z="16000.000*mm" zmin="15990.707*mm" zmax="16009.294*mm" rmin="49.500*mm" rmax="1550.163*mm" bigDelta="5.000*mm">
+                <rings repeat="15" smallDelta="2.500*mm" rPhiOverlap="0.500*mm" nRPhiSegments="4" rOverlap="0.500*mm"/>
+            </discZPls>
+        </discs>
+    </detector>
+</detectors>

--- a/FCChh/compact/FCChh_Option3_v03/FCChh_v3.03_Definitions.xml
+++ b/FCChh/compact/FCChh_Option3_v03/FCChh_v3.03_Definitions.xml
@@ -1,5 +1,5 @@
 <detectors>
-    <detector name="InnerBRL_0" id="BarTrackerInner_id" type="TkLayoutBrlTracker" readout="TrackerBarrelReadout">
+    <detector name="InnerBRL_0" id="13" type="TkLayoutBrlTracker" readout="TrackerBarrelReadout1">
         <dimensions rmin="23.283*mm" rmax="152.256*mm" zmin="-820.000*mm" zmax="820.000*mm"/>
         <sensitive type="SimpleTrackerSD"/>
         <layers repeat="4">
@@ -421,7 +421,7 @@
             </layer>
         </layers>
     </detector>
-    <detector name="InnerBRL_1" id="BarTrackerInner_id + 16" type="TkLayoutBrlTracker" readout="TrackerBarrelReadout">
+    <detector name="InnerBRL_1" id="14" type="TkLayoutBrlTracker" readout="TrackerBarrelReadout2">
         <dimensions rmin="261.066*mm" rmax="409.734*mm" zmin="-820.000*mm" zmax="820.000*mm"/>
         <sensitive type="SimpleTrackerSD"/>
         <layers repeat="2">
@@ -563,7 +563,7 @@
             </layer>
         </layers>
     </detector>
-    <detector name="InnerECAPpos" id="EndCapTrackerInner_id" type="TkLayoutEcapTracker" readout="TrackerEndcapReadout">
+    <detector name="InnerECAPpos" id="15" type="TkLayoutEcapTracker" readout="TrackerEndcapReadout1">
         <dimensions rmin="25.000*mm" rmax="403.728*mm" zmin="941.066*mm" zmax="2258.934*mm" reflect="false"/>
         <sensitive type="SimpleTrackerSD"/>
         <discs repeat="10">
@@ -653,7 +653,7 @@
             </discZPls>
         </discs>
     </detector>
-    <detector name="InnerECAPneg" id="EndCapTrackerInner_id + 16" type="TkLayoutEcapTracker" readout="TrackerEndcapReadout">
+    <detector name="InnerECAPneg" id="16" type="TkLayoutEcapTracker" readout="TrackerEndcapReadout2">
         <dimensions rmin="25.000*mm" rmax="403.728*mm" zmin="941.066*mm" zmax="2258.934*mm" reflect="true"/>
         <sensitive type="SimpleTrackerSD"/>
         <discs repeat="10">
@@ -743,7 +743,7 @@
             </discZPls>
         </discs>
     </detector>
-    <detector name="OuterBRL" id="BarTrackerOuter_id" type="TkLayoutBrlTracker" readout="TrackerBarrelReadout">
+    <detector name="OuterBRL" id="17" type="TkLayoutBrlTracker" readout="TrackerBarrelReadout3">
         <dimensions rmin="521.016*mm" rmax="1526.688*mm" zmin="-2250.000*mm" zmax="2250.000*mm"/>
         <sensitive type="SimpleTrackerSD"/>
         <layers repeat="6">
@@ -1517,7 +1517,7 @@
             </layer>
         </layers>
     </detector>
-    <detector name="OuterECAPpos" id="EndCapTrackerOuter_id" type="TkLayoutEcapTracker" readout="TrackerEndcapReadout">
+    <detector name="OuterECAPpos" id="18" type="TkLayoutEcapTracker" readout="TrackerEndcapReadout3">
         <dimensions rmin="25.000*mm" rmax="1549.268*mm" zmin="2615.706*mm" zmax="5009.294*mm" reflect="false"/>
         <sensitive type="SimpleTrackerSD"/>
         <discs repeat="12">
@@ -1814,7 +1814,7 @@
             </discZPls>
         </discs>
     </detector>
-    <detector name="OuterECAPneg" id="EndCapTrackerOuter_id + 16" type="TkLayoutEcapTracker" readout="TrackerEndcapReadout">
+    <detector name="OuterECAPneg" id="19" type="TkLayoutEcapTracker" readout="TrackerEndcapReadout4">
         <dimensions rmin="25.000*mm" rmax="1549.268*mm" zmin="2615.706*mm" zmax="5009.294*mm" reflect="true"/>
         <sensitive type="SimpleTrackerSD"/>
         <discs repeat="12">
@@ -2111,7 +2111,7 @@
             </discZPls>
         </discs>
     </detector>
-    <detector name="FwdIECAPpos" id="29" type="TkLayoutConicalEcapTracker" readout="TrackerEndcapReadout">
+    <detector name="FwdIECAPpos" id="20" type="TkLayoutConicalEcapTracker" readout="TrackerEndcapReadout5">
         <dimensions rmin1="25.000*mm" rmax1="943*mm" rmin2="25.000*mm" rmax2="1342*mm" zmin="6231.066*mm" zmax="8769.293*mm" reflect="false"/>
         <sensitive type="SimpleTrackerSD"/>
         <discs repeat="6">
@@ -2690,7 +2690,7 @@
             </discZPls>
         </discs>
     </detector>
-    <detector name="FwdIECAPneg" id="30" type="TkLayoutConicalEcapTracker" readout="TrackerEndcapReadout">
+    <detector name="FwdIECAPneg" id="21" type="TkLayoutConicalEcapTracker" readout="TrackerEndcapReadout5">
         <dimensions rmin1="25.000*mm" rmax1="943*mm" rmin2="25.000*mm" rmax2="1344*mm" zmin="6231.066*mm" zmax="8769.293*mm" reflect="true"/>
         <sensitive type="SimpleTrackerSD"/>
         <discs repeat="6">
@@ -3269,7 +3269,7 @@
             </discZPls>
         </discs>
     </detector>
-    <detector name="FwdECAPpos" id="27" type="TkLayoutEcapTracker" readout="TrackerEndcapReadout">
+    <detector name="FwdECAPpos" id="22" type="TkLayoutEcapTracker" readout="TrackerEndcapReadout6">
         <dimensions rmin="49.500*mm" rmax="1550.163*mm" zmin="9990.707*mm" zmax="16009.294*mm" reflect="false"/>
         <sensitive type="SimpleTrackerSD"/>
         <discs repeat="12">
@@ -3549,7 +3549,7 @@
             </discZPls>
         </discs>
     </detector>
-    <detector name="FwdECAPneg" id="28" type="TkLayoutEcapTracker" readout="TrackerEndcapReadout">
+    <detector name="FwdECAPneg" id="23" type="TkLayoutEcapTracker" readout="TrackerEndcapReadout6">
         <dimensions rmin="49.500*mm" rmax="1550.163*mm" zmin="9990.707*mm" zmax="16009.294*mm" reflect="true"/>
         <sensitive type="SimpleTrackerSD"/>
         <discs repeat="12">

--- a/FCChh/compact/FCChh_Option3_v03/elements.xml
+++ b/FCChh/compact/FCChh_Option3_v03/elements.xml
@@ -1,0 +1,884 @@
+<materials>
+ <element Z="89" formula="Ac" name="Ac" >
+  <atom type="A" unit="g/mol" value="227.028" />
+ </element>
+ <material formula="Ac" name="Actinium" state="solid" >
+  <RL type="X0" unit="cm" value="0.601558" />
+  <NIL type="lambda" unit="cm" value="21.2048" />
+  <D type="density" unit="g/cm3" value="10.07" />
+  <composite n="1" ref="Ac" />
+ </material>
+ <element Z="47" formula="Ag" name="Ag" >
+  <atom type="A" unit="g/mol" value="107.868" />
+ </element>
+ <material formula="Ag" name="Silver" state="solid" >
+  <RL type="X0" unit="cm" value="0.854292" />
+  <NIL type="lambda" unit="cm" value="15.8546" />
+  <D type="density" unit="g/cm3" value="10.5" />
+  <composite n="1" ref="Ag" />
+ </material>
+ <element Z="13" formula="Al" name="Al" >
+  <atom type="A" unit="g/mol" value="26.9815" />
+ </element>
+ <material formula="Al" name="Aluminum" state="solid" >
+  <RL type="X0" unit="cm" value="8.89632" />
+  <NIL type="lambda" unit="cm" value="38.8766" />
+  <D type="density" unit="g/cm3" value="2.699" />
+  <composite n="1" ref="Al" />
+ </material>
+ <element Z="95" formula="Am" name="Am" >
+  <atom type="A" unit="g/mol" value="243.061" />
+ </element>
+ <material formula="Am" name="Americium" state="solid" >
+  <RL type="X0" unit="cm" value="0.42431" />
+  <NIL type="lambda" unit="cm" value="15.9812" />
+  <D type="density" unit="g/cm3" value="13.67" />
+  <composite n="1" ref="Am" />
+ </material>
+ <element Z="18" formula="Ar" name="Ar" >
+  <atom type="A" unit="g/mol" value="39.9477" />
+ </element>
+ <material formula="Ar" name="Argon" state="gas" >
+  <RL type="X0" unit="cm" value="11762.1" />
+  <NIL type="lambda" unit="cm" value="71926" />
+  <D type="density" unit="g/cm3" value="0.00166201" />
+  <composite n="1" ref="Ar" />
+ </material>
+ <element Z="33" formula="As" name="As" >
+  <atom type="A" unit="g/mol" value="74.9216" />
+ </element>
+ <material formula="As" name="Arsenic" state="solid" >
+  <RL type="X0" unit="cm" value="2.0838" />
+  <NIL type="lambda" unit="cm" value="25.7324" />
+  <D type="density" unit="g/cm3" value="5.73" />
+  <composite n="1" ref="As" />
+ </material>
+ <element Z="85" formula="At" name="At" >
+  <atom type="A" unit="g/mol" value="209.987" />
+ </element>
+ <material formula="At" name="Astatine" state="solid" >
+  <RL type="X0" unit="cm" value="0.650799" />
+  <NIL type="lambda" unit="cm" value="22.3202" />
+  <D type="density" unit="g/cm3" value="9.32" />
+  <composite n="1" ref="At" />
+ </material>
+ <element Z="79" formula="Au" name="Au" >
+  <atom type="A" unit="g/mol" value="196.967" />
+ </element>
+ <material formula="Au" name="Gold" state="solid" >
+  <RL type="X0" unit="cm" value="0.334436" />
+  <NIL type="lambda" unit="cm" value="10.5393" />
+  <D type="density" unit="g/cm3" value="19.32" />
+  <composite n="1" ref="Au" />
+ </material>
+ <element Z="5" formula="B" name="B" >
+  <atom type="A" unit="g/mol" value="10.811" />
+ </element>
+ <material formula="B" name="Boron" state="solid" >
+  <RL type="X0" unit="cm" value="22.2307" />
+  <NIL type="lambda" unit="cm" value="32.2793" />
+  <D type="density" unit="g/cm3" value="2.37" />
+  <composite n="1" ref="B" />
+ </material>
+ <element Z="56" formula="Ba" name="Ba" >
+  <atom type="A" unit="g/mol" value="137.327" />
+ </element>
+ <material formula="Ba" name="Barium" state="solid" >
+  <RL type="X0" unit="cm" value="2.37332" />
+  <NIL type="lambda" unit="cm" value="51.6743" />
+  <D type="density" unit="g/cm3" value="3.5" />
+  <composite n="1" ref="Ba" />
+ </material>
+ <element Z="4" formula="Be" name="Be" >
+  <atom type="A" unit="g/mol" value="9.01218" />
+ </element>
+ <material formula="Be" name="Beryllium" state="solid" >
+  <RL type="X0" unit="cm" value="35.276" />
+  <NIL type="lambda" unit="cm" value="39.4488" />
+  <D type="density" unit="g/cm3" value="1.848" />
+  <composite n="1" ref="Be" />
+ </material>
+ <element Z="83" formula="Bi" name="Bi" >
+  <atom type="A" unit="g/mol" value="208.98" />
+ </element>
+ <material formula="Bi" name="Bismuth" state="solid" >
+  <RL type="X0" unit="cm" value="0.645388" />
+  <NIL type="lambda" unit="cm" value="21.3078" />
+  <D type="density" unit="g/cm3" value="9.747" />
+  <composite n="1" ref="Bi" />
+ </material>
+ <element Z="97" formula="Bk" name="Bk" >
+  <atom type="A" unit="g/mol" value="247.07" />
+ </element>
+ <material formula="Bk" name="Berkelium" state="solid" >
+  <RL type="X0" unit="cm" value="0.406479" />
+  <NIL type="lambda" unit="cm" value="15.6902" />
+  <D type="density" unit="g/cm3" value="14" />
+  <composite n="1" ref="Bk" />
+ </material>
+ <element Z="35" formula="Br" name="Br" >
+  <atom type="A" unit="g/mol" value="79.9035" />
+ </element>
+ <material formula="Br" name="Bromine" state="gas" >
+  <RL type="X0" unit="cm" value="1615.12" />
+  <NIL type="lambda" unit="cm" value="21299" />
+  <D type="density" unit="g/cm3" value="0.0070721" />
+  <composite n="1" ref="Br" />
+ </material>
+ <element Z="6" formula="C" name="C" >
+  <atom type="A" unit="g/mol" value="12.0107" />
+ </element>
+ <material formula="C" name="Carbon" state="solid" >
+  <RL type="X0" unit="cm" value="21.3485" />
+  <NIL type="lambda" unit="cm" value="40.1008" />
+  <D type="density" unit="g/cm3" value="2" />
+  <composite n="1" ref="C" />
+ </material>
+ <element Z="20" formula="Ca" name="Ca" >
+  <atom type="A" unit="g/mol" value="40.078" />
+ </element>
+ <material formula="Ca" name="Calcium" state="solid" >
+  <RL type="X0" unit="cm" value="10.4151" />
+  <NIL type="lambda" unit="cm" value="77.3754" />
+  <D type="density" unit="g/cm3" value="1.55" />
+  <composite n="1" ref="Ca" />
+ </material>
+ <element Z="48" formula="Cd" name="Cd" >
+  <atom type="A" unit="g/mol" value="112.411" />
+ </element>
+ <material formula="Cd" name="Cadmium" state="solid" >
+  <RL type="X0" unit="cm" value="1.03994" />
+  <NIL type="lambda" unit="cm" value="19.46" />
+  <D type="density" unit="g/cm3" value="8.65" />
+  <composite n="1" ref="Cd" />
+ </material>
+ <element Z="58" formula="Ce" name="Ce" >
+  <atom type="A" unit="g/mol" value="140.115" />
+ </element>
+ <material formula="Ce" name="Cerium" state="solid" >
+  <RL type="X0" unit="cm" value="1.19506" />
+  <NIL type="lambda" unit="cm" value="27.3227" />
+  <D type="density" unit="g/cm3" value="6.657" />
+  <composite n="1" ref="Ce" />
+ </material>
+ <element Z="98" formula="Cf" name="Cf" >
+  <atom type="A" unit="g/mol" value="251.08" />
+ </element>
+ <material formula="Cf" name="Californium" state="solid" >
+  <RL type="X0" unit="cm" value="0.568328" />
+  <NIL type="lambda" unit="cm" value="22.085" />
+  <D type="density" unit="g/cm3" value="10" />
+  <composite n="1" ref="Cf" />
+ </material>
+ <element Z="17" formula="Cl" name="Cl" >
+  <atom type="A" unit="g/mol" value="35.4526" />
+ </element>
+ <material formula="Cl" name="Chlorine" state="gas" >
+  <RL type="X0" unit="cm" value="6437.34" />
+  <NIL type="lambda" unit="cm" value="38723.9" />
+  <D type="density" unit="g/cm3" value="0.00299473" />
+  <composite n="1" ref="Cl" />
+ </material>
+ <element Z="96" formula="Cm" name="Cm" >
+  <atom type="A" unit="g/mol" value="247.07" />
+ </element>
+ <material formula="Cm" name="Curium" state="solid" >
+  <RL type="X0" unit="cm" value="0.428706" />
+  <NIL type="lambda" unit="cm" value="16.2593" />
+  <D type="density" unit="g/cm3" value="13.51" />
+  <composite n="1" ref="Cm" />
+ </material>
+ <element Z="27" formula="Co" name="Co" >
+  <atom type="A" unit="g/mol" value="58.9332" />
+ </element>
+ <material formula="Co" name="Cobalt" state="solid" >
+  <RL type="X0" unit="cm" value="1.53005" />
+  <NIL type="lambda" unit="cm" value="15.2922" />
+  <D type="density" unit="g/cm3" value="8.9" />
+  <composite n="1" ref="Co" />
+ </material>
+ <element Z="24" formula="Cr" name="Cr" >
+  <atom type="A" unit="g/mol" value="51.9961" />
+ </element>
+ <material formula="Cr" name="Chromium" state="solid" >
+  <RL type="X0" unit="cm" value="2.0814" />
+  <NIL type="lambda" unit="cm" value="18.1933" />
+  <D type="density" unit="g/cm3" value="7.18" />
+  <composite n="1" ref="Cr" />
+ </material>
+ <element Z="55" formula="Cs" name="Cs" >
+  <atom type="A" unit="g/mol" value="132.905" />
+ </element>
+ <material formula="Cs" name="Cesium" state="solid" >
+  <RL type="X0" unit="cm" value="4.4342" />
+  <NIL type="lambda" unit="cm" value="95.317" />
+  <D type="density" unit="g/cm3" value="1.873" />
+  <composite n="1" ref="Cs" />
+ </material>
+ <element Z="29" formula="Cu" name="Cu" >
+  <atom type="A" unit="g/mol" value="63.5456" />
+ </element>
+ <material formula="Cu" name="Copper" state="solid" >
+  <RL type="X0" unit="cm" value="1.43558" />
+  <NIL type="lambda" unit="cm" value="15.5141" />
+  <D type="density" unit="g/cm3" value="8.96" />
+  <composite n="1" ref="Cu" />
+ </material>
+ <element Z="66" formula="Dy" name="Dy" >
+  <atom type="A" unit="g/mol" value="162.497" />
+ </element>
+ <material formula="Dy" name="Dysprosium" state="solid" >
+  <RL type="X0" unit="cm" value="0.85614" />
+  <NIL type="lambda" unit="cm" value="22.2923" />
+  <D type="density" unit="g/cm3" value="8.55" />
+  <composite n="1" ref="Dy" />
+ </material>
+ <element Z="68" formula="Er" name="Er" >
+  <atom type="A" unit="g/mol" value="167.256" />
+ </element>
+ <material formula="Er" name="Erbium" state="solid" >
+  <RL type="X0" unit="cm" value="0.788094" />
+  <NIL type="lambda" unit="cm" value="21.2923" />
+  <D type="density" unit="g/cm3" value="9.066" />
+  <composite n="1" ref="Er" />
+ </material>
+ <element Z="63" formula="Eu" name="Eu" >
+  <atom type="A" unit="g/mol" value="151.964" />
+ </element>
+ <material formula="Eu" name="Europium" state="solid" >
+  <RL type="X0" unit="cm" value="1.41868" />
+  <NIL type="lambda" unit="cm" value="35.6178" />
+  <D type="density" unit="g/cm3" value="5.243" />
+  <composite n="1" ref="Eu" />
+ </material>
+ <element Z="9" formula="F" name="F" >
+  <atom type="A" unit="g/mol" value="18.9984" />
+ </element>
+ <material formula="F" name="Fluorine" state="gas" >
+  <RL type="X0" unit="cm" value="20838.2" />
+  <NIL type="lambda" unit="cm" value="59094.3" />
+  <D type="density" unit="g/cm3" value="0.00158029" />
+  <composite n="1" ref="F" />
+ </material>
+ <element Z="26" formula="Fe" name="Fe" >
+  <atom type="A" unit="g/mol" value="55.8451" />
+ </element>
+ <material formula="Fe" name="Iron" state="solid" >
+  <RL type="X0" unit="cm" value="1.75749" />
+  <NIL type="lambda" unit="cm" value="16.959" />
+  <D type="density" unit="g/cm3" value="7.874" />
+  <composite n="1" ref="Fe" />
+ </material>
+ <element Z="87" formula="Fr" name="Fr" >
+  <atom type="A" unit="g/mol" value="223.02" />
+ </element>
+ <material formula="Fr" name="Francium" state="solid" >
+  <RL type="X0" unit="cm" value="6.18826" />
+  <NIL type="lambda" unit="cm" value="212.263" />
+  <D type="density" unit="g/cm3" value="1" />
+  <composite n="1" ref="Fr" />
+ </material>
+ <element Z="31" formula="Ga" name="Ga" >
+  <atom type="A" unit="g/mol" value="69.7231" />
+ </element>
+ <material formula="Ga" name="Gallium" state="solid" >
+  <RL type="X0" unit="cm" value="2.1128" />
+  <NIL type="lambda" unit="cm" value="24.3351" />
+  <D type="density" unit="g/cm3" value="5.904" />
+  <composite n="1" ref="Ga" />
+ </material>
+ <element Z="64" formula="Gd" name="Gd" >
+  <atom type="A" unit="g/mol" value="157.252" />
+ </element>
+ <material formula="Gd" name="Gadolinium" state="solid" >
+  <RL type="X0" unit="cm" value="0.947208" />
+  <NIL type="lambda" unit="cm" value="23.9377" />
+  <D type="density" unit="g/cm3" value="7.9004" />
+  <composite n="1" ref="Gd" />
+ </material>
+ <element Z="32" formula="Ge" name="Ge" >
+  <atom type="A" unit="g/mol" value="72.6128" />
+ </element>
+ <material formula="Ge" name="Germanium" state="solid" >
+  <RL type="X0" unit="cm" value="2.3013" />
+  <NIL type="lambda" unit="cm" value="27.3344" />
+  <D type="density" unit="g/cm3" value="5.323" />
+  <composite n="1" ref="Ge" />
+ </material>
+ <element Z="1" formula="H" name="H" >
+  <atom type="A" unit="g/mol" value="1.00794" />
+ </element>
+ <material formula="H" name="Hydrogen" state="gas" >
+  <RL type="X0" unit="cm" value="752776" />
+  <NIL type="lambda" unit="cm" value="421239" />
+  <D type="density" unit="g/cm3" value="8.3748e-05" />
+  <composite n="1" ref="H" />
+ </material>
+ <element Z="2" formula="He" name="He" >
+  <atom type="A" unit="g/mol" value="4.00264" />
+ </element>
+ <material formula="He" name="Helium" state="gas" >
+  <RL type="X0" unit="cm" value="567113" />
+  <NIL type="lambda" unit="cm" value="334266" />
+  <D type="density" unit="g/cm3" value="0.000166322" />
+  <composite n="1" ref="He" />
+ </material>
+ <element Z="72" formula="Hf" name="Hf" >
+  <atom type="A" unit="g/mol" value="178.485" />
+ </element>
+ <material formula="Hf" name="Hafnium" state="solid" >
+  <RL type="X0" unit="cm" value="0.517717" />
+  <NIL type="lambda" unit="cm" value="14.7771" />
+  <D type="density" unit="g/cm3" value="13.31" />
+  <composite n="1" ref="Hf" />
+ </material>
+ <element Z="80" formula="Hg" name="Hg" >
+  <atom type="A" unit="g/mol" value="200.599" />
+ </element>
+ <material formula="Hg" name="Mercury" state="solid" >
+  <RL type="X0" unit="cm" value="0.475241" />
+  <NIL type="lambda" unit="cm" value="15.105" />
+  <D type="density" unit="g/cm3" value="13.546" />
+  <composite n="1" ref="Hg" />
+ </material>
+ <element Z="67" formula="Ho" name="Ho" >
+  <atom type="A" unit="g/mol" value="164.93" />
+ </element>
+ <material formula="Ho" name="Holmium" state="solid" >
+  <RL type="X0" unit="cm" value="0.822447" />
+  <NIL type="lambda" unit="cm" value="21.8177" />
+  <D type="density" unit="g/cm3" value="8.795" />
+  <composite n="1" ref="Ho" />
+ </material>
+ <element Z="53" formula="I" name="I" >
+  <atom type="A" unit="g/mol" value="126.904" />
+ </element>
+ <material formula="I" name="Iodine" state="solid" >
+  <RL type="X0" unit="cm" value="1.72016" />
+  <NIL type="lambda" unit="cm" value="35.6583" />
+  <D type="density" unit="g/cm3" value="4.93" />
+  <composite n="1" ref="I" />
+ </material>
+ <element Z="49" formula="In" name="In" >
+  <atom type="A" unit="g/mol" value="114.818" />
+ </element>
+ <material formula="In" name="Indium" state="solid" >
+  <RL type="X0" unit="cm" value="1.21055" />
+  <NIL type="lambda" unit="cm" value="23.2468" />
+  <D type="density" unit="g/cm3" value="7.31" />
+  <composite n="1" ref="In" />
+ </material>
+ <element Z="77" formula="Ir" name="Ir" >
+  <atom type="A" unit="g/mol" value="192.216" />
+ </element>
+ <material formula="Ir" name="Iridium" state="solid" >
+  <RL type="X0" unit="cm" value="0.294142" />
+  <NIL type="lambda" unit="cm" value="9.01616" />
+  <D type="density" unit="g/cm3" value="22.42" />
+  <composite n="1" ref="Ir" />
+ </material>
+ <element Z="19" formula="K" name="K" >
+  <atom type="A" unit="g/mol" value="39.0983" />
+ </element>
+ <material formula="K" name="Potassium" state="solid" >
+  <RL type="X0" unit="cm" value="20.0871" />
+  <NIL type="lambda" unit="cm" value="138.041" />
+  <D type="density" unit="g/cm3" value="0.862" />
+  <composite n="1" ref="K" />
+ </material>
+ <element Z="36" formula="Kr" name="Kr" >
+  <atom type="A" unit="g/mol" value="83.7993" />
+ </element>
+ <material formula="Kr" name="Krypton" state="gas" >
+  <RL type="X0" unit="cm" value="3269.44" />
+  <NIL type="lambda" unit="cm" value="43962.9" />
+  <D type="density" unit="g/cm3" value="0.00347832" />
+  <composite n="1" ref="Kr" />
+ </material>
+ <element Z="57" formula="La" name="La" >
+  <atom type="A" unit="g/mol" value="138.905" />
+ </element>
+ <material formula="La" name="Lanthanum" state="solid" >
+  <RL type="X0" unit="cm" value="1.32238" />
+  <NIL type="lambda" unit="cm" value="29.441" />
+  <D type="density" unit="g/cm3" value="6.154" />
+  <composite n="1" ref="La" />
+ </material>
+ <element Z="3" formula="Li" name="Li" >
+  <atom type="A" unit="g/mol" value="6.94003" />
+ </element>
+ <material formula="Li" name="Lithium" state="solid" >
+  <RL type="X0" unit="cm" value="154.997" />
+  <NIL type="lambda" unit="cm" value="124.305" />
+  <D type="density" unit="g/cm3" value="0.534" />
+  <composite n="1" ref="Li" />
+ </material>
+ <element Z="71" formula="Lu" name="Lu" >
+  <atom type="A" unit="g/mol" value="174.967" />
+ </element>
+ <material formula="Lu" name="Lutetium" state="solid" >
+  <RL type="X0" unit="cm" value="0.703651" />
+  <NIL type="lambda" unit="cm" value="19.8916" />
+  <D type="density" unit="g/cm3" value="9.84" />
+  <composite n="1" ref="Lu" />
+ </material>
+ <element Z="12" formula="Mg" name="Mg" >
+  <atom type="A" unit="g/mol" value="24.305" />
+ </element>
+ <material formula="Mg" name="Magnesium" state="solid" >
+  <RL type="X0" unit="cm" value="14.3859" />
+  <NIL type="lambda" unit="cm" value="58.7589" />
+  <D type="density" unit="g/cm3" value="1.74" />
+  <composite n="1" ref="Mg" />
+ </material>
+ <element Z="25" formula="Mn" name="Mn" >
+  <atom type="A" unit="g/mol" value="54.938" />
+ </element>
+ <material formula="Mn" name="Manganese" state="solid" >
+  <RL type="X0" unit="cm" value="1.96772" />
+  <NIL type="lambda" unit="cm" value="17.8701" />
+  <D type="density" unit="g/cm3" value="7.44" />
+  <composite n="1" ref="Mn" />
+ </material>
+ <element Z="42" formula="Mo" name="Mo" >
+  <atom type="A" unit="g/mol" value="95.9313" />
+ </element>
+ <material formula="Mo" name="Molybdenum" state="solid" >
+  <RL type="X0" unit="cm" value="0.959107" />
+  <NIL type="lambda" unit="cm" value="15.6698" />
+  <D type="density" unit="g/cm3" value="10.22" />
+  <composite n="1" ref="Mo" />
+ </material>
+ <element Z="7" formula="N" name="N" >
+  <atom type="A" unit="g/mol" value="14.0068" />
+ </element>
+ <material formula="N" name="Nitrogen" state="gas" >
+  <RL type="X0" unit="cm" value="32602.2" />
+  <NIL type="lambda" unit="cm" value="72430.3" />
+  <D type="density" unit="g/cm3" value="0.0011652" />
+  <composite n="1" ref="N" />
+ </material>
+ <element Z="11" formula="Na" name="Na" >
+  <atom type="A" unit="g/mol" value="22.9898" />
+ </element>
+ <material formula="Na" name="Sodium" state="solid" >
+  <RL type="X0" unit="cm" value="28.5646" />
+  <NIL type="lambda" unit="cm" value="102.463" />
+  <D type="density" unit="g/cm3" value="0.971" />
+  <composite n="1" ref="Na" />
+ </material>
+ <element Z="41" formula="Nb" name="Nb" >
+  <atom type="A" unit="g/mol" value="92.9064" />
+ </element>
+ <material formula="Nb" name="Niobium" state="solid" >
+  <RL type="X0" unit="cm" value="1.15783" />
+  <NIL type="lambda" unit="cm" value="18.4846" />
+  <D type="density" unit="g/cm3" value="8.57" />
+  <composite n="1" ref="Nb" />
+ </material>
+ <element Z="60" formula="Nd" name="Nd" >
+  <atom type="A" unit="g/mol" value="144.236" />
+ </element>
+ <material formula="Nd" name="Neodymium" state="solid" >
+  <RL type="X0" unit="cm" value="1.11667" />
+  <NIL type="lambda" unit="cm" value="26.6308" />
+  <D type="density" unit="g/cm3" value="6.9" />
+  <composite n="1" ref="Nd" />
+ </material>
+ <element Z="10" formula="Ne" name="Ne" >
+  <atom type="A" unit="g/mol" value="20.18" />
+ </element>
+ <material formula="Ne" name="Neon" state="gas" >
+  <RL type="X0" unit="cm" value="34504.8" />
+  <NIL type="lambda" unit="cm" value="114322" />
+  <D type="density" unit="g/cm3" value="0.000838505" />
+  <composite n="1" ref="Ne" />
+ </material>
+ <element Z="28" formula="Ni" name="Ni" >
+  <atom type="A" unit="g/mol" value="58.6933" />
+ </element>
+ <material formula="Ni" name="Nickel" state="solid" >
+  <RL type="X0" unit="cm" value="1.42422" />
+  <NIL type="lambda" unit="cm" value="15.2265" />
+  <D type="density" unit="g/cm3" value="8.902" />
+  <composite n="1" ref="Ni" />
+ </material>
+ <element Z="93" formula="Np" name="Np" >
+  <atom type="A" unit="g/mol" value="237.048" />
+ </element>
+ <material formula="Np" name="Neptunium" state="solid" >
+  <RL type="X0" unit="cm" value="0.289676" />
+  <NIL type="lambda" unit="cm" value="10.6983" />
+  <D type="density" unit="g/cm3" value="20.25" />
+  <composite n="1" ref="Np" />
+ </material>
+ <element Z="8" formula="O" name="O" >
+  <atom type="A" unit="g/mol" value="15.9994" />
+ </element>
+ <material formula="O" name="Oxygen" state="gas" >
+  <RL type="X0" unit="cm" value="25713.8" />
+  <NIL type="lambda" unit="cm" value="66233.9" />
+  <D type="density" unit="g/cm3" value="0.00133151" />
+  <composite n="1" ref="O" />
+ </material>
+ <element Z="76" formula="Os" name="Os" >
+  <atom type="A" unit="g/mol" value="190.225" />
+ </element>
+ <material formula="Os" name="Osmium" state="solid" >
+  <RL type="X0" unit="cm" value="0.295861" />
+  <NIL type="lambda" unit="cm" value="8.92553" />
+  <D type="density" unit="g/cm3" value="22.57" />
+  <composite n="1" ref="Os" />
+ </material>
+ <element Z="15" formula="P" name="P" >
+  <atom type="A" unit="g/mol" value="30.9738" />
+ </element>
+ <material formula="P" name="Phosphorus" state="solid" >
+  <RL type="X0" unit="cm" value="9.63879" />
+  <NIL type="lambda" unit="cm" value="49.9343" />
+  <D type="density" unit="g/cm3" value="2.2" />
+  <composite n="1" ref="P" />
+ </material>
+ <element Z="91" formula="Pa" name="Pa" >
+  <atom type="A" unit="g/mol" value="231.036" />
+ </element>
+ <material formula="Pa" name="Protactinium" state="solid" >
+  <RL type="X0" unit="cm" value="0.38607" />
+  <NIL type="lambda" unit="cm" value="13.9744" />
+  <D type="density" unit="g/cm3" value="15.37" />
+  <composite n="1" ref="Pa" />
+ </material>
+ <element Z="82" formula="Pb" name="Pb" >
+  <atom type="A" unit="g/mol" value="207.217" />
+ </element>
+ <material formula="Pb" name="Lead" state="solid" >
+  <RL type="X0" unit="cm" value="0.561253" />
+  <NIL type="lambda" unit="cm" value="18.2607" />
+  <D type="density" unit="g/cm3" value="11.35" />
+  <composite n="1" ref="Pb" />
+ </material>
+ <element Z="46" formula="Pd" name="Pd" >
+  <atom type="A" unit="g/mol" value="106.415" />
+ </element>
+ <material formula="Pd" name="Palladium" state="solid" >
+  <RL type="X0" unit="cm" value="0.765717" />
+  <NIL type="lambda" unit="cm" value="13.7482" />
+  <D type="density" unit="g/cm3" value="12.02" />
+  <composite n="1" ref="Pd" />
+ </material>
+ <element Z="61" formula="Pm" name="Pm" >
+  <atom type="A" unit="g/mol" value="144.913" />
+ </element>
+ <material formula="Pm" name="Promethium" state="solid" >
+  <RL type="X0" unit="cm" value="1.04085" />
+  <NIL type="lambda" unit="cm" value="25.4523" />
+  <D type="density" unit="g/cm3" value="7.22" />
+  <composite n="1" ref="Pm" />
+ </material>
+ <element Z="84" formula="Po" name="Po" >
+  <atom type="A" unit="g/mol" value="208.982" />
+ </element>
+ <material formula="Po" name="Polonium" state="solid" >
+  <RL type="X0" unit="cm" value="0.661092" />
+  <NIL type="lambda" unit="cm" value="22.2842" />
+  <D type="density" unit="g/cm3" value="9.32" />
+  <composite n="1" ref="Po" />
+ </material>
+ <element Z="59" formula="Pr" name="Pr" >
+  <atom type="A" unit="g/mol" value="140.908" />
+ </element>
+ <material formula="Pr" name="Praseodymium" state="solid" >
+  <RL type="X0" unit="cm" value="1.1562" />
+  <NIL type="lambda" unit="cm" value="27.1312" />
+  <D type="density" unit="g/cm3" value="6.71" />
+  <composite n="1" ref="Pr" />
+ </material>
+ <element Z="78" formula="Pt" name="Pt" >
+  <atom type="A" unit="g/mol" value="195.078" />
+ </element>
+ <material formula="Pt" name="Platinum" state="solid" >
+  <RL type="X0" unit="cm" value="0.305053" />
+  <NIL type="lambda" unit="cm" value="9.46584" />
+  <D type="density" unit="g/cm3" value="21.45" />
+  <composite n="1" ref="Pt" />
+ </material>
+ <element Z="94" formula="Pu" name="Pu" >
+  <atom type="A" unit="g/mol" value="244.064" />
+ </element>
+ <material formula="Pu" name="Plutonium" state="solid" >
+  <RL type="X0" unit="cm" value="0.298905" />
+  <NIL type="lambda" unit="cm" value="11.0265" />
+  <D type="density" unit="g/cm3" value="19.84" />
+  <composite n="1" ref="Pu" />
+ </material>
+ <element Z="88" formula="Ra" name="Ra" >
+  <atom type="A" unit="g/mol" value="226.025" />
+ </element>
+ <material formula="Ra" name="Radium" state="solid" >
+  <RL type="X0" unit="cm" value="1.22987" />
+  <NIL type="lambda" unit="cm" value="42.6431" />
+  <D type="density" unit="g/cm3" value="5" />
+  <composite n="1" ref="Ra" />
+ </material>
+ <element Z="37" formula="Rb" name="Rb" >
+  <atom type="A" unit="g/mol" value="85.4677" />
+ </element>
+ <material formula="Rb" name="Rubidium" state="solid" >
+  <RL type="X0" unit="cm" value="7.19774" />
+  <NIL type="lambda" unit="cm" value="100.218" />
+  <D type="density" unit="g/cm3" value="1.532" />
+  <composite n="1" ref="Rb" />
+ </material>
+ <element Z="75" formula="Re" name="Re" >
+  <atom type="A" unit="g/mol" value="186.207" />
+ </element>
+ <material formula="Re" name="Rhenium" state="solid" >
+  <RL type="X0" unit="cm" value="0.318283" />
+  <NIL type="lambda" unit="cm" value="9.5153" />
+  <D type="density" unit="g/cm3" value="21.02" />
+  <composite n="1" ref="Re" />
+ </material>
+ <element Z="45" formula="Rh" name="Rh" >
+  <atom type="A" unit="g/mol" value="102.906" />
+ </element>
+ <material formula="Rh" name="Rhodium" state="solid" >
+  <RL type="X0" unit="cm" value="0.746619" />
+  <NIL type="lambda" unit="cm" value="13.2083" />
+  <D type="density" unit="g/cm3" value="12.41" />
+  <composite n="1" ref="Rh" />
+ </material>
+ <element Z="86" formula="Rn" name="Rn" >
+  <atom type="A" unit="g/mol" value="222.018" />
+ </element>
+ <material formula="Rn" name="Radon" state="gas" >
+  <RL type="X0" unit="cm" value="697.777" />
+  <NIL type="lambda" unit="cm" value="23532" />
+  <D type="density" unit="g/cm3" value="0.00900662" />
+  <composite n="1" ref="Rn" />
+ </material>
+ <element Z="44" formula="Ru" name="Ru" >
+  <atom type="A" unit="g/mol" value="101.065" />
+ </element>
+ <material formula="Ru" name="Ruthenium" state="solid" >
+  <RL type="X0" unit="cm" value="0.764067" />
+  <NIL type="lambda" unit="cm" value="13.1426" />
+  <D type="density" unit="g/cm3" value="12.41" />
+  <composite n="1" ref="Ru" />
+ </material>
+ <element Z="16" formula="S" name="S" >
+  <atom type="A" unit="g/mol" value="32.0661" />
+ </element>
+ <material formula="S" name="Sulfur" state="solid" >
+  <RL type="X0" unit="cm" value="9.74829" />
+  <NIL type="lambda" unit="cm" value="55.6738" />
+  <D type="density" unit="g/cm3" value="2" />
+  <composite n="1" ref="S" />
+ </material>
+ <element Z="51" formula="Sb" name="Sb" >
+  <atom type="A" unit="g/mol" value="121.76" />
+ </element>
+ <material formula="Sb" name="Antimony" state="solid" >
+  <RL type="X0" unit="cm" value="1.30401" />
+  <NIL type="lambda" unit="cm" value="25.8925" />
+  <D type="density" unit="g/cm3" value="6.691" />
+  <composite n="1" ref="Sb" />
+ </material>
+ <element Z="21" formula="Sc" name="Sc" >
+  <atom type="A" unit="g/mol" value="44.9559" />
+ </element>
+ <material formula="Sc" name="Scandium" state="solid" >
+  <RL type="X0" unit="cm" value="5.53545" />
+  <NIL type="lambda" unit="cm" value="41.609" />
+  <D type="density" unit="g/cm3" value="2.989" />
+  <composite n="1" ref="Sc" />
+ </material>
+ <element Z="34" formula="Se" name="Se" >
+  <atom type="A" unit="g/mol" value="78.9594" />
+ </element>
+ <material formula="Se" name="Selenium" state="solid" >
+  <RL type="X0" unit="cm" value="2.64625" />
+  <NIL type="lambda" unit="cm" value="33.356" />
+  <D type="density" unit="g/cm3" value="4.5" />
+  <composite n="1" ref="Se" />
+ </material>
+ <element Z="14" formula="Si" name="Si" >
+  <atom type="A" unit="g/mol" value="28.0854" />
+ </element>
+ <material formula="Si" name="Silicon" state="solid" >
+  <RL type="X0" unit="cm" value="9.36607" />
+  <NIL type="lambda" unit="cm" value="45.7531" />
+  <D type="density" unit="g/cm3" value="2.33" />
+  <composite n="1" ref="Si" />
+ </material>
+ <element Z="62" formula="Sm" name="Sm" >
+  <atom type="A" unit="g/mol" value="150.366" />
+ </element>
+ <material formula="Sm" name="Samarium" state="solid" >
+  <RL type="X0" unit="cm" value="1.01524" />
+  <NIL type="lambda" unit="cm" value="24.9892" />
+  <D type="density" unit="g/cm3" value="7.46" />
+  <composite n="1" ref="Sm" />
+ </material>
+ <element Z="50" formula="Sn" name="Sn" >
+  <atom type="A" unit="g/mol" value="118.71" />
+ </element>
+ <material formula="Sn" name="Tin" state="solid" >
+  <RL type="X0" unit="cm" value="1.20637" />
+  <NIL type="lambda" unit="cm" value="23.4931" />
+  <D type="density" unit="g/cm3" value="7.31" />
+  <composite n="1" ref="Sn" />
+ </material>
+ <element Z="38" formula="Sr" name="Sr" >
+  <atom type="A" unit="g/mol" value="87.6166" />
+ </element>
+ <material formula="Sr" name="Strontium" state="solid" >
+  <RL type="X0" unit="cm" value="4.237" />
+  <NIL type="lambda" unit="cm" value="61.0238" />
+  <D type="density" unit="g/cm3" value="2.54" />
+  <composite n="1" ref="Sr" />
+ </material>
+ <element Z="73" formula="Ta" name="Ta" >
+  <atom type="A" unit="g/mol" value="180.948" />
+ </element>
+ <material formula="Ta" name="Tantalum" state="solid" >
+  <RL type="X0" unit="cm" value="0.409392" />
+  <NIL type="lambda" unit="cm" value="11.8846" />
+  <D type="density" unit="g/cm3" value="16.654" />
+  <composite n="1" ref="Ta" />
+ </material>
+ <element Z="65" formula="Tb" name="Tb" >
+  <atom type="A" unit="g/mol" value="158.925" />
+ </element>
+ <material formula="Tb" name="Terbium" state="solid" >
+  <RL type="X0" unit="cm" value="0.893977" />
+  <NIL type="lambda" unit="cm" value="23.0311" />
+  <D type="density" unit="g/cm3" value="8.229" />
+  <composite n="1" ref="Tb" />
+ </material>
+ <element Z="43" formula="Tc" name="Tc" >
+  <atom type="A" unit="g/mol" value="97.9072" />
+ </element>
+ <material formula="Tc" name="Technetium" state="solid" >
+  <RL type="X0" unit="cm" value="0.833149" />
+  <NIL type="lambda" unit="cm" value="14.0185" />
+  <D type="density" unit="g/cm3" value="11.5" />
+  <composite n="1" ref="Tc" />
+ </material>
+ <element Z="52" formula="Te" name="Te" >
+  <atom type="A" unit="g/mol" value="127.603" />
+ </element>
+ <material formula="Te" name="Tellurium" state="solid" >
+  <RL type="X0" unit="cm" value="1.41457" />
+  <NIL type="lambda" unit="cm" value="28.1797" />
+  <D type="density" unit="g/cm3" value="6.24" />
+  <composite n="1" ref="Te" />
+ </material>
+ <element Z="90" formula="Th" name="Th" >
+  <atom type="A" unit="g/mol" value="232.038" />
+ </element>
+ <material formula="Th" name="Thorium" state="solid" >
+  <RL type="X0" unit="cm" value="0.51823" />
+  <NIL type="lambda" unit="cm" value="18.353" />
+  <D type="density" unit="g/cm3" value="11.72" />
+  <composite n="1" ref="Th" />
+ </material>
+ <element Z="22" formula="Ti" name="Ti" >
+  <atom type="A" unit="g/mol" value="47.8667" />
+ </element>
+ <material formula="Ti" name="Titanium" state="solid" >
+  <RL type="X0" unit="cm" value="3.5602" />
+  <NIL type="lambda" unit="cm" value="27.9395" />
+  <D type="density" unit="g/cm3" value="4.54" />
+  <composite n="1" ref="Ti" />
+ </material>
+ <element Z="81" formula="Tl" name="Tl" >
+  <atom type="A" unit="g/mol" value="204.383" />
+ </element>
+ <material formula="Tl" name="Thallium" state="solid" >
+  <RL type="X0" unit="cm" value="0.547665" />
+  <NIL type="lambda" unit="cm" value="17.6129" />
+  <D type="density" unit="g/cm3" value="11.72" />
+  <composite n="1" ref="Tl" />
+ </material>
+ <element Z="69" formula="Tm" name="Tm" >
+  <atom type="A" unit="g/mol" value="168.934" />
+ </element>
+ <material formula="Tm" name="Thulium" state="solid" >
+  <RL type="X0" unit="cm" value="0.754428" />
+  <NIL type="lambda" unit="cm" value="20.7522" />
+  <D type="density" unit="g/cm3" value="9.321" />
+  <composite n="1" ref="Tm" />
+ </material>
+ <element Z="92" formula="U" name="U" >
+  <atom type="A" unit="g/mol" value="238.029" />
+ </element>
+ <material formula="U" name="Uranium" state="solid" >
+  <RL type="X0" unit="cm" value="0.31663" />
+  <NIL type="lambda" unit="cm" value="11.4473" />
+  <D type="density" unit="g/cm3" value="18.95" />
+  <composite n="1" ref="U" />
+ </material>
+ <element Z="23" formula="V" name="V" >
+  <atom type="A" unit="g/mol" value="50.9415" />
+ </element>
+ <material formula="V" name="Vanadium" state="solid" >
+  <RL type="X0" unit="cm" value="2.59285" />
+  <NIL type="lambda" unit="cm" value="21.2187" />
+  <D type="density" unit="g/cm3" value="6.11" />
+  <composite n="1" ref="V" />
+ </material>
+ <element Z="74" formula="W" name="W" >
+  <atom type="A" unit="g/mol" value="183.842" />
+ </element>
+ <material formula="W" name="Tungsten" state="solid" >
+  <RL type="X0" unit="cm" value="0.350418" />
+  <NIL type="lambda" unit="cm" value="10.3057" />
+  <D type="density" unit="g/cm3" value="19.3" />
+  <composite n="1" ref="W" />
+ </material>
+ <element Z="54" formula="Xe" name="Xe" >
+  <atom type="A" unit="g/mol" value="131.292" />
+ </element>
+ <material formula="Xe" name="Xenon" state="gas" >
+  <RL type="X0" unit="cm" value="1546.2" />
+  <NIL type="lambda" unit="cm" value="32477.9" />
+  <D type="density" unit="g/cm3" value="0.00548536" />
+  <composite n="1" ref="Xe" />
+ </material>
+ <element Z="39" formula="Y" name="Y" >
+  <atom type="A" unit="g/mol" value="88.9058" />
+ </element>
+ <material formula="Y" name="Yttrium" state="solid" >
+  <RL type="X0" unit="cm" value="2.32943" />
+  <NIL type="lambda" unit="cm" value="34.9297" />
+  <D type="density" unit="g/cm3" value="4.469" />
+  <composite n="1" ref="Y" />
+ </material>
+ <element Z="70" formula="Yb" name="Yb" >
+  <atom type="A" unit="g/mol" value="173.038" />
+ </element>
+ <material formula="Yb" name="Ytterbium" state="solid" >
+  <RL type="X0" unit="cm" value="1.04332" />
+  <NIL type="lambda" unit="cm" value="28.9843" />
+  <D type="density" unit="g/cm3" value="6.73" />
+  <composite n="1" ref="Yb" />
+ </material>
+ <element Z="30" formula="Zn" name="Zn" >
+  <atom type="A" unit="g/mol" value="65.3955" />
+ </element>
+ <material formula="Zn" name="Zinc" state="solid" >
+  <RL type="X0" unit="cm" value="1.74286" />
+  <NIL type="lambda" unit="cm" value="19.8488" />
+  <D type="density" unit="g/cm3" value="7.133" />
+  <composite n="1" ref="Zn" />
+ </material>
+ <element Z="40" formula="Zr" name="Zr" >
+  <atom type="A" unit="g/mol" value="91.2236" />
+ </element>
+ <material formula="Zr" name="Zirconium" state="solid" >
+  <RL type="X0" unit="cm" value="1.56707" />
+  <NIL type="lambda" unit="cm" value="24.2568" />
+  <D type="density" unit="g/cm3" value="6.506" />
+  <composite n="1" ref="Zr" />
+ </material>
+</materials>

--- a/FCChh/compact/FCChh_Option3_v03/materials.xml
+++ b/FCChh/compact/FCChh_Option3_v03/materials.xml
@@ -1,0 +1,168 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<materials>
+
+  <material name="PbWO4">
+    <D type="density" unit="g/cm3" value="8.280"/>
+    <composite n="1" ref="Pb"/>
+    <composite n="1" ref="W"/>
+    <composite n="4" ref="O"/>
+  </material>
+
+  <material name="FR4">
+    <D type="density" unit="g/cm3" value="1.7"/>
+    <fraction n="0.1808" ref="Si"/>
+    <fraction n="0.4056" ref="O"/>
+    <fraction n="0.2780" ref="C"/>
+    <fraction n="0.0684" ref="H"/>
+    <fraction n="0.0671" ref="Br"/>
+  </material>
+
+  <!--
+       Air by weight from
+
+       http://www.engineeringtoolbox.com/air-composition-24_212.html
+  -->
+
+  <material name="Air">
+    <D type="density" unit="g/cm3" value="0.0012"/>
+    <fraction n="0.754" ref="N"/>
+    <fraction n="0.234" ref="O"/>
+    <fraction n="0.012" ref="Ar"/>
+  </material>
+
+  <material name="Vacuum">
+    <D type="density" unit="g/cm3" value="0.00000001" />
+    <fraction n="1" ref="H" />
+  </material>
+
+  <material name="Epoxy">
+    <D type="density" value="1.3" unit="g/cm3"/>
+    <composite n="44" ref="H"/>
+    <composite n="15" ref="C"/>
+    <composite n="7" ref="O"/>
+  </material>
+
+  <material name="Quartz">
+    <D type="density" value="2.2" unit="g/cm3"/>
+    <composite n="1" ref="Si"/>
+    <composite n="2" ref="O"/>
+  </material>
+
+  <material name="G10">
+    <D type="density" value="1.7" unit="g/cm3"/>
+    <fraction n="0.08" ref="Cl"/>
+    <fraction n="0.773" ref="Quartz"/>
+    <fraction n="0.147" ref="Epoxy"/>
+  </material>
+
+  <material name="Polystyrene">
+    <D value="1.032" unit="g/cm3"/>
+    <composite n="19" ref="C"/>
+    <composite n="21" ref="H"/>
+  </material>
+
+  <material name="Steel235">
+    <D value="7.85" unit="g/cm3"/>
+    <fraction n="0.998" ref="Fe"/>
+    <fraction n=".002" ref="C"/>
+  </material>
+
+  <material name="SiliconOxide">
+    <D type="density" value="2.65" unit="g/cm3"/>
+    <composite n="1" ref="Si"/>
+    <composite n="2" ref="O"/>
+  </material>
+
+  <material name="BoronOxide">
+    <D type="density" value="2.46" unit="g/cm3"/>
+    <composite n="2" ref="B"/>
+    <composite n="3" ref="O"/>
+  </material>
+
+  <material name="SodiumOxide">
+    <D type="density" value="2.65" unit="g/cm3"/>
+    <composite n="2" ref="Na"/>
+    <composite n="1" ref="O"/>
+  </material>
+
+  <material name="AluminumOxide">
+    <D type="density" value="3.89" unit="g/cm3"/>
+    <composite n="2" ref="Al"/>
+    <composite n="3" ref="O"/>
+  </material>
+
+  <material name="PyrexGlass">
+    <D type="density" value="2.23" unit="g/cm3"/>
+    <fraction n="0.806" ref="SiliconOxide"/>
+    <fraction n="0.130" ref="BoronOxide"/>
+    <fraction n="0.040" ref="SodiumOxide"/>
+    <fraction n="0.023" ref="AluminumOxide"/>
+  </material>
+
+  <material name="CarbonFiber">
+    <D type="density" value="1.5" unit="g/cm3"/>
+    <fraction n="0.65" ref="C"/>
+    <fraction n="0.35" ref="Epoxy"/>
+  </material>
+  
+  <material name="CarbonFiber_50D">
+    <D type="density" value="0.75" unit="g/cm3"/>
+    <fraction n="0.65" ref="C"/>
+    <fraction n="0.35" ref="Epoxy"/>
+  </material>  
+
+  <material name="Rohacell31">
+    <D type="density" value="0.032" unit="g/cm3"/>
+    <composite n="9" ref="C"/>
+    <composite n="13" ref="H"/>
+    <composite n="2" ref="O"/>
+    <composite n="1" ref="N"/>
+  </material>
+  
+  <material name="Rohacell31_50D">
+    <D type="density" value="0.016" unit="g/cm3"/>
+    <composite n="9" ref="C"/>
+    <composite n="13" ref="H"/>
+    <composite n="2" ref="O"/>
+    <composite n="1" ref="N"/>
+  </material>  
+
+  <material name="RPCGasDefault" state="gas">
+    <D type="density" value="0.0037" unit="g/cm3"/>
+    <composite n="209" ref="C"/>
+    <composite n="239" ref="H"/>
+    <composite n="381" ref="F"/>
+  </material>
+
+  <material name="PolystyreneFoam">
+    <D type="density" value="0.0056" unit="g/cm3"/>
+    <fraction n="1.0" ref="Polystyrene"/>
+  </material>
+
+  <material name="PE">
+    <D type="density" value="0.95" unit="g/cm3"/>
+    <fraction n="4" ref="H"/>
+    <fraction n="2" ref="C"/>
+  </material>
+
+  <material name="Kapton">
+    <D value="1.43" unit="g/cm3" />
+    <composite n="22" ref="C"/>
+    <composite n="10" ref="H" />
+    <composite n="2" ref="N" />
+    <composite n="5" ref="O" />
+  </material>
+
+  <material name="PEEK">
+    <D value="1.37" unit="g/cm3" />
+    <composite n="19" ref="C"/>
+    <composite n="12" ref="H" />
+    <composite n="3" ref="O" />
+  </material>
+
+  <material name="LAr">
+    <D value="1.396" unit="g/cm3" />
+    <composite n="1" ref="Ar"/>
+  </material>
+
+</materials>

--- a/detector/TkLayout/TkLayoutBarrel_Geo.cpp
+++ b/detector/TkLayout/TkLayoutBarrel_Geo.cpp
@@ -1,6 +1,8 @@
 
 #include "DetCommon/DetUtils.h"
 
+
+
 #include "DD4hep/DetFactoryHelper.h"
 
 using DD4hep::Geometry::Volume;
@@ -9,7 +11,6 @@ using DD4hep::XML::Dimension;
 using DD4hep::Geometry::PlacedVolume;
 
 namespace det {
-
 static DD4hep::Geometry::Ref_t createTkLayoutTrackerBarrel(DD4hep::Geometry::LCDD& lcdd,
                                                            DD4hep::XML::Handle_t xmlElement,
                                                            DD4hep::Geometry::SensitiveDetector sensDet) {
@@ -17,7 +18,7 @@ static DD4hep::Geometry::Ref_t createTkLayoutTrackerBarrel(DD4hep::Geometry::LCD
   DD4hep::XML::DetElement xmlDet = static_cast<DD4hep::XML::DetElement>(xmlElement);
   Dimension dimensions(xmlDet.dimensions());
   // get sensitive detector type from xml
-  DD4hep::XML::Dimension sdTyp = xmlElement.child("sensitive");
+  DD4hep::XML::Dimension sdTyp = xmlElement.child(_Unicode(sensitive));
   // sensitive detector used for all sensitive parts of this detector
   sensDet.setType(sdTyp.typeStr());
 
@@ -33,14 +34,10 @@ static DD4hep::Geometry::Ref_t createTkLayoutTrackerBarrel(DD4hep::Geometry::LCD
   // counts all layers - incremented in the inner loop over repeat - tags
   unsigned int layerCounter = 0;
   double integratedModuleComponentThickness = 0;
-  unsigned int moduleComponentCounter = 0;
-  unsigned int nPhi;
   double phi = 0;
   // loop over 'layer' nodes in xml
-  DD4hep::XML::Component xLayers = xmlElement.child("layers");
+  DD4hep::XML::Component xLayers = xmlElement.child(_Unicode(layers));
   for (DD4hep::XML::Collection_t xLayerColl(xLayers, _U(layer)); nullptr != xLayerColl; ++xLayerColl) {
-    PlacedVolume sensitivePlacement;
-
     DD4hep::XML::Component xLayer = static_cast<DD4hep::XML::Component>(xLayerColl);
     DD4hep::XML::Component xRods = xLayer.child("rods");
     DD4hep::XML::Component xRodEven = xRods.child("rodOdd");
@@ -48,75 +45,61 @@ static DD4hep::Geometry::Ref_t createTkLayoutTrackerBarrel(DD4hep::Geometry::LCD
     DD4hep::XML::Component xModulesEven = xRodEven.child("modules");
     DD4hep::XML::Component xModulePropertiesOdd = xRodOdd.child("moduleProperties");
     DD4hep::XML::Component xModulesOdd = xRodOdd.child("modules");
-    Volume moduleVolume("module",
-                        DD4hep::Geometry::Box(0.5 * xModulePropertiesOdd.attr<double>("modWidth"),
-                                              0.5 * xModulePropertiesOdd.attr<double>("modThickness"),
-                                              0.5 * xModulePropertiesOdd.attr<double>("modLength")),
-                        lcdd.material("Air"));
-    // moduleVolume.setVisAttributes(lcdd, xModulePropertiesOdd.visStr());
+    DD4hep::Geometry::Tube layerShape(xLayer.rmin(), xLayer.rmax(), dimensions.zmax());
+    Volume layerVolume("layer", layerShape, lcdd.material("Air"));
+    //layerVolume.setVisAttributes(lcdd.invisible());
+    PlacedVolume placedLayerVolume = topVolume.placeVolume(layerVolume);
+    placedLayerVolume.addPhysVolID("layer", layerCounter);
+    DetElement lay_det(topDetElement, "layer" + std::to_string(layerCounter), layerCounter);
+    lay_det.setPlacement(placedLayerVolume);
     DD4hep::XML::Component xModuleComponentsOdd = xModulePropertiesOdd.child("components");
     integratedModuleComponentThickness = 0;
-    moduleComponentCounter = 0;
+    int moduleCounter = 0;
+    Volume moduleVolume;
     for (DD4hep::XML::Collection_t xModuleComponentOddColl(xModuleComponentsOdd, _U(component));
          nullptr != xModuleComponentOddColl;
          ++xModuleComponentOddColl) {
       DD4hep::XML::Component xModuleComponentOdd = static_cast<DD4hep::XML::Component>(xModuleComponentOddColl);
-      Volume moduleComponentVolume(xModuleComponentOdd.nameStr(),
-                                   DD4hep::Geometry::Box(0.5 * xModulePropertiesOdd.attr<double>("modWidth"),
-                                                         0.5 * xModuleComponentOdd.thickness(),
-                                                         0.5 * xModulePropertiesOdd.attr<double>("modLength")),
-                                   lcdd.material(xModuleComponentOdd.materialStr()));
-      DD4hep::Geometry::Position offset(
-          0, integratedModuleComponentThickness - 0.5 * xModulePropertiesOdd.attr<double>("modThickness") + 0.5 * xModuleComponentOdd.thickness(), 0);
+      moduleVolume = Volume("module",
+                            DD4hep::Geometry::Box(0.5 * xModulePropertiesOdd.attr<double>("modWidth"),
+                                                  0.5 * xModuleComponentOdd.thickness(),
+                                                  0.5 * xModulePropertiesOdd.attr<double>("modLength")),
+                            lcdd.material(xModuleComponentOdd.materialStr()));
+      moduleVolume.setVisAttributes(lcdd.invisible());
+      unsigned int nPhi = xRods.repeat();
+      DD4hep::XML::Handle_t currentComp;
+      for (unsigned int phiIndex = 0; phiIndex < nPhi; ++phiIndex) {
+        double lX = 0;
+        double lY = 0;
+        double lZ = 0;
+        if (0 == phiIndex % 2) {
+          phi = 2 * M_PI * static_cast<double>(phiIndex) / static_cast<double>(nPhi);
+          currentComp = xModulesEven;
+        } else {
+          currentComp = xModulesOdd;
+        }
+        for (DD4hep::XML::Collection_t xModuleColl(currentComp, _U(module)); nullptr != xModuleColl; ++xModuleColl) {
+          DD4hep::XML::Component xModule = static_cast<DD4hep::XML::Component>(xModuleColl);
+          double currentPhi = atan2(xModule.Y(), xModule.X());
+          double componentOffset =  integratedModuleComponentThickness - 0.5 * xModulePropertiesOdd.attr<double>("modThickness") + 0.5 * xModuleComponentOdd.thickness();
+          lX = xModule.X() + cos(currentPhi) * componentOffset;
+          lY = xModule.Y() + sin(currentPhi) * componentOffset;
+          lZ = xModule.Z();
+          DD4hep::Geometry::Translation3D moduleOffset(lX, lY, lZ);
+          DD4hep::Geometry::Transform3D lTrafo(DD4hep::Geometry::RotationZ(atan2(lY,  lX) + 0.5 * M_PI), moduleOffset);
+          DD4hep::Geometry::RotationZ lRotation(phi);
+          PlacedVolume placedModuleVolume = layerVolume.placeVolume(moduleVolume, lRotation * lTrafo);
+          if (xModuleComponentOdd.isSensitive()) {
+            placedModuleVolume.addPhysVolID("module", moduleCounter);
+            moduleVolume.setSensitiveDetector(sensDet);
+            DetElement mod_det(lay_det, "module" + std::to_string(moduleCounter), moduleCounter);
+            mod_det.setPlacement(placedModuleVolume);
+            ++moduleCounter;
+          }
+        }
+      }
       integratedModuleComponentThickness += xModuleComponentOdd.thickness();
-
-
-      PlacedVolume placedModuleComponentVolume = moduleVolume.placeVolume(moduleComponentVolume, offset);
-      // placedModuleComponentVolume.addPhysVolID("component", moduleComponentCounter);
-      ++moduleComponentCounter;
-      if( xModuleComponentOdd.isSensitive() ) {
-	moduleComponentVolume.setSensitiveDetector(sensDet);
-	sensitivePlacement = placedModuleComponentVolume;
-      }
     }
-    // definition of layer volumes
-    double lX, lY, lZ;
-    DD4hep::Geometry::Tube layerShape(xLayer.rmin(), xLayer.rmax(), dimensions.zmax());
-    Volume layerVolume("layer", layerShape, lcdd.material("Air"));
-    layerVolume.setVisAttributes(lcdd.invisible());
-    PlacedVolume placedLayerVolume = topVolume.placeVolume(layerVolume);
-    placedLayerVolume.addPhysVolID("layer", layerCounter);
-    DetElement lay_det(topDetElement, "layer" + std::to_string(layerCounter), layerCounter);
-    nPhi = xRods.repeat();
-    int moduleCounter = 0;
-    DD4hep::XML::Handle_t currentComp;
-    for (unsigned int phiIndex = 0; phiIndex < nPhi; ++phiIndex) {
-      if (0 == phiIndex % 2) {
-        phi = 2 * M_PI * static_cast<double>(phiIndex) / static_cast<double>(nPhi);
-        currentComp = xModulesEven;
-      } else {
-        currentComp = xModulesOdd;
-      }
-      for (DD4hep::XML::Collection_t xModuleColl(currentComp, _U(module)); nullptr != xModuleColl; ++xModuleColl) {
-        DD4hep::XML::Component xModule = static_cast<DD4hep::XML::Component>(xModuleColl);
-        lX = xModule.X();
-        lY = xModule.Y();
-        lZ = xModule.Z();
-        DD4hep::Geometry::Translation3D moduleOffset(lX, lY, lZ);
-        DD4hep::Geometry::Transform3D lTrafo(DD4hep::Geometry::RotationZ(atan(lY / lX) + 0.5 * M_PI), moduleOffset);
-        DD4hep::Geometry::RotationZ lRotation(phi);
-        PlacedVolume placedModuleVolume = layerVolume.placeVolume(moduleVolume, lRotation * lTrafo);
-        placedModuleVolume.addPhysVolID("module", moduleCounter);
-        DetElement mod_det("module" + std::to_string(moduleCounter), moduleCounter);
-	mod_det.setPlacement(placedModuleVolume);
-	lay_det.add(mod_det);
-	DetElement detSensor( mod_det, "sensor", xmlDet.id());
-	detSensor.setPlacement( sensitivePlacement );
-
-        ++moduleCounter;
-      }
-    }
-    lay_det.setPlacement(placedLayerVolume);
     ++layerCounter;
   }
   Volume motherVol = lcdd.pickMotherVolume(topDetElement);

--- a/detector/TkLayout/TkLayoutConicalEndcap_Geo.cpp
+++ b/detector/TkLayout/TkLayoutConicalEndcap_Geo.cpp
@@ -138,12 +138,14 @@ static DD4hep::Geometry::Ref_t createTkLayoutTrackerConicalEndcap(DD4hep::Geomet
   double envelopeNegRotAngle = 0;
   if (dimensions.reflect()) {
     envelopeNegRotAngle = dd4hep::pi;
+  }
+  DD4hep::Geometry::RotationX envelopeNegRotation(envelopeNegRotAngle);
+  PlacedVolume placedEnvelopeVolume = motherVol.placeVolume(envelopeVolume, envelopeNegRotation * envelopeTranslation);
+  if (dimensions.reflect()) {
     placedEnvelopeVolume.addPhysVolID("side", -1);
   } else {
     placedEnvelopeVolume.addPhysVolID("side", 1);
   }
-  DD4hep::Geometry::RotationX envelopeNegRotation(envelopeNegRotAngle);
-  PlacedVolume placedEnvelopeVolume = motherVol.placeVolume(envelopeVolume, envelopeNegRotation * envelopeTranslation);
   placedEnvelopeVolume.addPhysVolID("system", xmlDet.id());
   worldDetElement.setPlacement(placedEnvelopeVolume);
   return worldDetElement;

--- a/detector/TkLayout/TkLayoutEndcap_Geo.cpp
+++ b/detector/TkLayout/TkLayoutEndcap_Geo.cpp
@@ -138,13 +138,15 @@ static DD4hep::Geometry::Ref_t createTkLayoutTrackerEndcap(DD4hep::Geometry::LCD
   double envelopeNegRotAngle = 0;
   if (dimensions.reflect()) {
     envelopeNegRotAngle = dd4hep::pi;
-    placedEnvelopeVolume.addPhysVolID("side", -1);
-  } else {
-    placedEnvelopeVolume.addPhysVolID("side", 1);
   }
 
   DD4hep::Geometry::RotationX envelopeNegRotation(envelopeNegRotAngle);
   PlacedVolume placedEnvelopeVolume = motherVol.placeVolume(envelopeVolume, envelopeNegRotation * envelopeTranslation);
+  if (dimensions.reflect()) {
+    placedEnvelopeVolume.addPhysVolID("side", -1);
+  } else {
+    placedEnvelopeVolume.addPhysVolID("side", 1);
+  }
   placedEnvelopeVolume.addPhysVolID("system", xmlDet.id());
   worldDetElement.setPlacement(placedEnvelopeVolume);
   return worldDetElement;


### PR DESCRIPTION

BEGINRELEASENOTES
- Update cpp factories and add compact files corresponding to http://fcc-tklayout.web.cern.ch/fcc-tklayout/FCChh_v3.03/index.html

ENDRELEASENOTES


This even supports v4.01 (tilted)
In principle I also wanted to do a rewrite of the factories, to create only the the DetElements in the innermost loop and take advantage of symmetries when positioning the volumes, but I will have to feed this back later.